### PR TITLE
Input validation fixes and organizer/curator home pages

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -173,6 +173,7 @@ def save_seminar():
     def make_error(shortname, col=None, err=None, msg=None):
         if err is not None:
             flash_error("Error processing %s: {0}".format(err), col)
+            return failure()
         if msg is not None:
             flash_error(msg)
         seminar = WebSeminar(shortname)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -249,6 +249,8 @@ def save_seminar():
             except Exception as err:
                 return make_error(shortname, col, err)
         if D.get("homepage") or D.get("email") or D.get("full_name"):
+            if not D.get("full_name"):
+                return make_error(shortname,msg="Organizer name cannot be blank")
             D["order"] = len(organizer_data)
             # WARNING the header on the template says organizer
             # but it sets the database column curator, so the 

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -267,7 +267,7 @@ def save_seminar():
         new_version.save()
         edittype = "created" if new else "edited"
         flash("Seminar %s successfully!" % edittype)
-    elif list_of_dicts_equal(seminar.organizer_data,new_version.organizer_data):
+    elif seminar.organizer_data == new_version.organizer_data:
         flash("No changes made to seminar.")
     if seminar.new or seminar.organizer_data != new_version.organizer_data:
         new_version.save_organizers()

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -215,7 +215,7 @@ def save_seminar():
             else:
                 data[col] = process_user_input(val, replace(db.seminars.col_type[col]), tz=tz)
         except Exception as err:
-            errmsgs.append(format_errmsg("Error processing %s: {0}".format(err), col))
+            errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     data["institutions"] = clean_institutions(data.get("institutions"))
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))
@@ -241,10 +241,10 @@ def save_seminar():
                 # if col == 'homepage' and val and not val.startswith("http"):
                 #     D[col] = "http://" + data[col]
             except Exception as err:
-                errmsgs.append(format_errmsg("Error processing %s: {0}".format(err), col))
+                errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
         if D.get("homepage") or D.get("email") or D.get("full_name"):
             if not D.get("full_name"):
-                errmsgs.append(format_errmsg("Organizer/curator name cannot be blank"))
+                errmsgs.append(format_errmsg("Organizer %s cannot be blank", "name"))
             D["order"] = len(organizer_data)
             # WARNING the header on the template says organizer
             # but it sets the database column curator, so the 
@@ -258,8 +258,8 @@ def save_seminar():
     if display_count == 0:
        errmsgs.append(format_errmsg("At least one organizer or curator must be displayed."))
     if email_count == 0:
-       errmsgs.append(format_errmsg("At least one organizer or curator needs an email address (to ensure someone can maintain this listing).<br>%s",
-                                    "This email will not be displayed if the homepage is set (or the display box is not checked)."))
+       errmsgs.append(format_errmsg("At least one organizer or curator needs %s set to ensure that someone can maintain this listing.<br>%s", "email"
+                                    "This information will not be displayed if homepage is set or display is not checked."))
     if errmsgs:
         return input_error(errmsgs)
     new_version = WebSeminar(shortname, data=data, organizer_data=organizer_data)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -225,14 +225,15 @@ def save_seminar():
             if col in D:
                 continue
             name = "org_%s%s" % (col, i)
+            typ = db.seminar_organizers.col_type[col]
             try:
                 val = raw_data.get(name)
                 if val == "":
                     D[col] = None
                 elif val is None:
-                    D[col] = False  # checkboxes
+                    D[col] = False if type == "boolean" else None  # checkboxes
                 else:
-                    D[col] = process_user_input(val, db.seminar_organizers.col_type[col], tz=tz)
+                    D[col] = process_user_input(val, typ, tz=tz)
                 # if col == 'homepage' and val and not val.startswith("http"):
                 #     D[col] = "http://" + data[col]
             except Exception as err:
@@ -266,11 +267,9 @@ def save_seminar():
         new_version.save()
         edittype = "created" if new else "edited"
         flash("Seminar %s successfully!" % edittype)
-    elif seminar.organizer_data == new_version.organizer_data:
+    elif list_of_dicts_equal(seminar.organizer_data,new_version.organizer_data):
         flash("No changes made to seminar.")
     if seminar.new or seminar.organizer_data != new_version.organizer_data:
-        print(seminar.organizer_data)
-        print(new_version.organizer_data)
         new_version.save_organizers()
         if not seminar.new:
             flash("Seminar organizers updated!")

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -262,7 +262,7 @@ def save_seminar():
        flash_error("At least one organizer or curator must be displayed.") 
        err = True
     if err:
-        return make_error(shortname, col, err)
+        return make_error(shortname, data=data)
     new_version = WebSeminar(shortname, data=data, organizer_data=organizer_data)
     if check_time(new_version.start_time, new_version.end_time):
         return make_error(shortname)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -175,7 +175,7 @@ def save_seminar():
             flash_error("Error processing %s: {0}".format(err), col)
         if msg is not None:
             flash_error(msg)
-        seminar = WebSeminar(shortname, data=raw_data)
+        seminar = WebSeminar(shortname)
         manage = "Manage" if current_user.is_organizer else "Create"
         return render_template(
             "edit_seminar.html",

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -269,6 +269,8 @@ def save_seminar():
     elif seminar.organizer_data == new_version.organizer_data:
         flash("No changes made to seminar.")
     if seminar.new or seminar.organizer_data != new_version.organizer_data:
+        print(seminar.organizer_data)
+        print(new_version.organizer_data)
         new_version.save_organizers()
         if not seminar.new:
             flash("Seminar organizers updated!")

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -175,6 +175,7 @@ def save_seminar():
             flash_error("Error processing %s: {0}".format(err), col)
         if msg is not None:
             flash_error(msg)
+        return
         seminar = WebSeminar(shortname, data=None, editing=True)
         manage = "Manage" if current_user.is_organizer else "Create"
         return render_template(

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import current_user
-from markupsafe import Markup, escape
 from seminars.users.main import email_confirmed_required
 from seminars import db
 from seminars.create import create
@@ -211,7 +210,7 @@ def save_seminar():
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     for col in ["frequency","per_day"]:
         if data[col] is not None and data[col] < 1:
-        errmsgs.append(format_errmsg("Unable to process input %s for %s: a positive integer is required", raw_data.get(col), col))
+            errmsgs.append(format_errmsg("Unable to process input %s for %s: a positive integer is required", raw_data.get(col), col))
     data["institutions"] = clean_institutions(data.get("institutions"))
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -261,7 +261,7 @@ def save_seminar():
     if display_count == 0:
        errmsgs.append(format_errmsg("At least one organizer or curator must be displayed."))
     if email_count == 0:
-       errmsgs.append(format_errmsg("At least one organizer or curator needs %s set to ensure that someone can maintain this listing.<br>%s", "email"
+       errmsgs.append(format_errmsg("At least one organizer or curator needs %s set to ensure that someone can maintain this listing.<br>%s", "email",
                                     "This information will not be displayed if homepage is set or display is not checked."))
     # Don't try to create new_version using invalid input
     if errmsgs:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -177,7 +177,7 @@ def save_seminar():
     def input_error(errmsgs):
         assert errmsgs
         for msg in errmsgs:
-            print msg
+            print(msg)
             flash_error(msg)
         return render_template("inputerror.html")
 

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -174,22 +174,12 @@ def save_seminar():
         return resp
     errmsgs = []
 
-    def make_error(shortname, data=None):
-        seminar = WebSeminar(shortname, data=data)
-        manage = "Manage" if current_user.is_organizer else "Create"
-        return render_template(
-            "edit_seminar.html",
-            seminar=seminar,
-            title="Edit seminar error",
-            section=manage,
-            institutions=institutions(),
-            lock=None,
-        )
     def input_error(errmsgs):
         assert errmsgs
         for msg in errmsgs:
-            flash(msg,"error")
-        return render_template("inputerror.html",messages=errmsgs)
+            print msg
+            flash_error(msg)
+        return render_template("inputerror.html")
 
     if seminar.new:
         data = {

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -263,10 +263,12 @@ def save_seminar():
     if email_count == 0:
        errmsgs.append(format_errmsg("At least one organizer or curator needs %s set to ensure that someone can maintain this listing.<br>%s", "email"
                                     "This information will not be displayed if homepage is set or display is not checked."))
+    # Don't try to create new_version using invalid input
+    if errmsgs:
+        return show_input_errors(errmsgs)
     new_version = WebSeminar(shortname, data=data, organizer_data=organizer_data)
     if check_time(new_version.start_time, new_version.end_time):
         errmsgs.append(format_errmsg("Incompatible or invalid start time %s and end time %s", new_version.start_time, new_version.end_time))
-    if errmsgs:
         return show_input_errors(errmsgs)
     if seminar.new or new_version != seminar:
         new_version.save()
@@ -463,10 +465,12 @@ def save_talk():
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))
+    # Don't try to create new_version using invalid input
+    if errmsgs:
+        return show_input_errors(errmsgs)
     new_version = WebTalk(talk.seminar_id, data["seminar_ctr"], data=data)
     if check_time(new_version.start_time, new_version.end_time, check_past=True):
         errmsgs.append(format_errmsg("Incompatible or invalid start time %s and end time %s", new_version.start_time, new_version.end_time))
-    if errmsgs:
         return show_input_errors(errmsgs)
     if new_version == talk:
         flash("No changes made to talk.")

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -173,10 +173,9 @@ def save_seminar():
     def make_error(shortname, col=None, err=None, msg=None):
         if err is not None:
             flash_error("Error processing %s: {0}".format(err), col)
-            return failure()
         if msg is not None:
             flash_error(msg)
-        seminar = WebSeminar(shortname)
+        seminar = WebSeminar(shortname, data=None, editing=True)
         manage = "Manage" if current_user.is_organizer else "Create"
         return render_template(
             "edit_seminar.html",

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -172,23 +172,23 @@
       Anyone with "Display" checked will be visible on the seminar's page, in the order below (in a separate list of "Curators" if "Organizer" is not checked); if in addition "Contact" is checked, their names there will be "mailto:" links.</p>
       <table>
         <thead>
-          <th>Email</th>
           <th>Name</th>
+          <th>Homepage</th>
+          <th>Email</th>
           <th>Organizer</th>
           <th>Display</th>
-          <th>Contact</th>
         </thead>
         {% for i in range(10) %}
         <tr>
           {% if i < (seminar.organizer_data | length) %}
             <td>
+              <input name="org_full_name{{i}}" value="{{ seminar.organizer_data[i].get('full_name') | blanknone }}" style="width:180px"/>
+            </td>
+            <td>
               <input name="org_homepage{{i}}" value="{{ seminar.organizer_data[i].get('homepage') | blanknone }}" style="width:220px"/>
             </td>
             <td>
               <input name="org_email{{i}}" value="{{ seminar.organizer_data[i].get('email') | blanknone }}" style="width:220px"/>
-            </td>
-            <td>
-              <input name="org_full_name{{i}}" value="{{ seminar.organizer_data[i].get('full_name') | blanknone }}" style="width:180px"/>
             </td>
             <td>
               {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}
@@ -199,9 +199,9 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizer_data[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
+            <td><input name="org_full_name{{i}}" style="width:180px;" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
-            <td><input name="org_full_name{{i}}" style="width:180px;" /></td>
             <td><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
             <td><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
           {% endif %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -173,7 +173,7 @@
       their name will be linked to their home page, and if homepage is not set but email is set their name will have a mailto link.</p>
       <table>
         <thead>
-          <th>{{ KNOWL("full_name") }}</th>
+          <th>{{ KNOWL("organizer_name") }}</th>
           <th>{{ KNOWL("homepage") }}</th>
           <th>{{ KNOWL("email") }}</th>
           <th>{{ KNOWL("organizer") }}</th>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -182,28 +182,28 @@
         <tr>
           {% if i < (seminar.organizer_data | length) %}
             <td>
+              <input name="org_homepage{{i}}" value="{{ seminar.organizer_data[i].get('homepage') | blanknone }}" style="width:220px"/>
+            </td>
+            <td>
               <input name="org_email{{i}}" value="{{ seminar.organizer_data[i].get('email') | blanknone }}" style="width:220px"/>
             </td>
             <td>
               <input name="org_full_name{{i}}" value="{{ seminar.organizer_data[i].get('full_name') | blanknone }}" style="width:180px"/>
             </td>
             <td>
-              {############ HOT FIX ###############}
-              {# WARNING: the header is organizer #}
+              {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}
+              {# but it is displayed in a column labeleled "organizer" so it is checked when curator is false #}
               <input type="checkbox" name="org_curator{{i}}" value="yes" {% if not seminar.organizer_data[i].get("curator") %}checked{% endif %} />
             </td>
             <td>
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizer_data[i].get("display") %}checked{% endif %} />
             </td>
-            <td>
-              <input type="checkbox" name="org_contact{{i}}" value="yes" {% if seminar.organizer_data[i].get("contact") %}checked{% endif %} />
-            </td>
           {% else %}
+            <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td><input name="org_full_name{{i}}" style="width:180px;" /></td>
             <td><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
             <td><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
-            <td><input type="checkbox" name="org_contact{{i}}" value="yes" /></td>
           {% endif %}
         </tr>
         {% endfor %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -169,7 +169,8 @@
       <p class="forminfo">
         Normally, leave "Organizer" checked; uncheck for a staff/student/postdoc assistant with permission to edit the seminar despite not being responsible for the scientific organization.
         </br>
-      Anyone with "Display" checked will be visible on the seminar's page, in the order below (in a separate list of "Curators" if "Organizer" is not checked); if in addition "Contact" is checked, their names there will be "mailto:" links.</p>
+      Anyone with "Display" checked will be visible on the seminar's page, in the order below (in a separate list of "Curators" if "Organizer" is not checked).  If homepage is set
+      their name will be linked to their home page, and if homepage is not set but email is set their name will have a mailto link.</p>
       <table>
         <thead>
           <th>Name</th>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -173,11 +173,11 @@
       their name will be linked to their home page, and if homepage is not set but email is set their name will have a mailto link.</p>
       <table>
         <thead>
-          <th>Name</th>
+          <th>{{ KNOWL("full_name") }}</th>
           <th>{{ KNOWL("homepage") }}</th>
           <th>{{ KNOWL("email") }}</th>
           <th>{{ KNOWL("organizer") }}</th>
-          <th>Display</th>
+          <th>{{ KNOWL("display") }}</th>
         </thead>
         {% for i in range(10) %}
         <tr>

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -1,5 +1,23 @@
+organizer_name:
+  title: Name
+  contents: |
+    The full name of the organizer (or curator) that will be displayed on the seminar's home page.  This cannot be left blank.
+homepage:
+  title: Homepage
+  contents: |
+    The URL of the homepage of the organizer (or curator) that their name will be linked to on the "view seminar" page.
+    Specifying the homepage ensures that their email address will be hidden.  Many organizers obfuscate their email addresses on their homepages and we want to preserve this obfuscation.
+email:
+  title: Email
+  contents: |
+    The email address of the organizer (or curator).  This will only be displayed if the homepage is not specified and the display box is checked.
+    In all other cases it is used only to identify the organizer's user account and will give them permission to edit the seminar (assuming the register using this email address).
 organizer:
   title: Organizer
   contents: |
     Check this box for organizers of the seminar responsible for its scientific content, inviting speakers, etc.
-    Leave this box unchecked for users who should be able to edit the seminar but are not responsible for its content.
+    Leave this box unchecked for users who should be able to edit the seminar but are not responsible for its content; these users will be listed as "Curators" on the seminar's home page.
+organizer:
+  title: Display
+  contents: |
+    Check this box for oragnizers (or curators) whose names should appear on the seminar's home page.  This box must be checked for at least one organizer or curator.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -17,7 +17,7 @@ organizer:
   contents: |
     Check this box for organizers of the seminar responsible for its scientific content, inviting speakers, etc.
     Leave this box unchecked for users who should be able to edit the seminar but are not responsible for its content; these users will be listed as "Curators" on the seminar's home page.
-organizer:
+display:
   title: Display
   contents: |
     Check this box for oragnizers (or curators) whose names should appear on the seminar's home page.  This box must be checked for at least one organizer or curator.

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -17,7 +17,6 @@ from lmfdb.utils import flash_error
 from lmfdb.backend.utils import DelayCommit, IdentifierWrapper
 from psycopg2.sql import SQL
 import pytz
-from sage.misc.lazy_attribute import lazy_attribute
 from collections import defaultdict
 from datetime import datetime
 from lmfdb.logger import critical
@@ -272,22 +271,16 @@ class WebSeminar(object):
             current_user.email_confirmed and current_user.email in self.editors()
         )
 
-    def _show_editors(self, label, negate=False):
+    def _show_editors(self, label, curators=False):
+        """ shows organizors (or curators if curators is True) """
         editors = []
         for rec in self.organizer_data:
-            show = rec["curator"]
-            if negate:
-                show = not show
+            show = rec["curator"] if curators else not rec["curator"]
             if show and rec["display"]:
-                name = rec["full_name"]
-                if not name:
-                    if not rec["contact"]:
-                        continue
-                    name = rec["email"]
-                if rec["contact"]:
-                    editors.append('<a href="mailto:%s">%s</a>' % (rec["email"], name))
-                else:
-                    editors.append(name)
+                link = rec["homepage"] if rec["homepage"] else "mailto:%s"%(rec["email"])
+                name = rec["name"] if rec["name"] else link
+                if name:
+                    editors.append('<a href="%s">%s</a>' % (link, name))
         if editors:
             return "<tr><td>%s:</td><td>%s</td></tr>" % (label, ", ".join(editors))
         else:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -287,10 +287,10 @@ class WebSeminar(object):
             return ""
 
     def show_organizers(self):
-        return self._show_editors("Organizers", negate=True)
+        return self._show_editors("Organizers")
 
     def show_curators(self):
-        return self._show_editors("Curators")
+        return self._show_editors("Curators", curators=True)
 
     def add_talk_link(self, ptag=True):
         if current_user.email in self.editors():

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -278,7 +278,7 @@ class WebSeminar(object):
             show = rec["curator"] if curators else not rec["curator"]
             if show and rec["display"]:
                 link = rec["homepage"] if rec["homepage"] else "mailto:%s"%(rec["email"])
-                name = rec["name"] if rec["name"] else link
+                name = rec["full_name"] if rec["full_name"] else link
                 if name:
                     editors.append('<a href="%s">%s</a>' % (link, name))
         if editors:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -283,7 +283,8 @@ class WebSeminar(object):
                 link = rec["homepage"] if rec["homepage"] else "mailto:%s"%(rec["email"])
                 name = rec["full_name"] if rec["full_name"] else link
                 if name:
-                    editors.append('<a href="%s">%s</a>' % (link, name))
+                    editors.append('<a href="%s">%s</a>' % (link, name) if link else name)
+
         if editors:
             return "<tr><td>%s:</td><td>%s</td></tr>" % (label, ", ".join(editors))
         else:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -39,6 +39,8 @@ class WebSeminar(object):
                 data["topics"] = []
             if data.get("institutions") is None:
                 data["institutions"] = []
+            if data.get("timezone") is None:
+                data["timesone"] = str(current_user.tz)
         self.new = data is None
         if self.new:
             self.shortname = shortname

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -5,13 +5,13 @@
 <div>
 One or more errors occured while processing the input you entered.
 </div>
-
-
+<br>
 <span style='color:black'>
 <div>
-Please press the back button on your browser, correct the errors listed above and press the save button again.
-<br>
-If you do not see any error message listed above, or if the error messages do not make clear what the problem is,
+Please press the back button on your browser, correct the errors listed above, then press the save button again.
+<br><br>
+
+If you do not see any error message listed above or if the error messages above are unclear,
 please help us to improve the website by <a href="{{ feedbackpage }}">reporting the problem</a>.
 </div>
 </span>

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -1,11 +1,14 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
+<div class="announce error">
 <div>
+We were unable to save the data you entered.
+</div>
 <br>
 <span style='color:black'>
 <div>
-Please press the back button on your browser, correct the errors listed above, then press the save button again.
+Please press the back button on your browser, correct the errors listed above, and then press the save button again.
 <br><br>
 
 If you do not see any error message listed above or if the error messages above are unclear,

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -1,10 +1,7 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-<div class="announce error">
 <div>
-One or more errors occured while processing the input you entered.
-</div>
 <br>
 <span style='color:black'>
 <div>
@@ -13,7 +10,6 @@ Please press the back button on your browser, correct the errors listed above, t
 
 If you do not see any error message listed above or if the error messages above are unclear,
 please help us to improve the website by <a href="{{ feedbackpage }}">reporting the problem</a>.
-</div>
 </span>
 </div>
 

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -13,8 +13,8 @@ A problem occured while trying to save the input you entered:
 {% elif message %}
 <br>
 {{ message }}
+<p>Please press the back button on your browser, correct the problems noted above, then press save again.</p>
 </div>
 
-Please press the back button on your browser, correct the problems noted above, then press save again.
 
 {% endblock %}

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -5,14 +5,11 @@
 <div>
 We were unable to save the data you entered.
 </div>
-<br>
 <span style='color:black'>
 <div>
-Please press the back button on your browser, correct the errors listed above, and then press the save button again.
-<br><br>
-
-If you do not see any error message listed above or if the error messages above are unclear,
-please help us to improve the website by <a href="{{ feedbackpage }}">reporting the problem</a>.
+<p>Please press the back button on your browser, correct the errors listed above, and then press the save button again.</p>
+<p>If you do not see any error message listed above or if the error messages above are unclear,
+please help us to improve the website by <a href="{{ feedbackpage }}">reporting the problem</a>.</p>
 </span>
 </div>
 

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -1,20 +1,20 @@
 {% extends 'homepage.html' %}
 {% block content %}
 
-<div class="announce red">
-<div>Unable to save data</div>
-A problem occured while trying to save the input you entered:
-{% if messages %}
-<ul>
-{% for msg in messages %}
-<li>{{msg}}</li>
-{% endfor %}
-</ul>
-{% elif message %}
-<br>
-{{ message }}
-<p>Please press the back button on your browser, correct the problems noted above, then press save again.</p>
+<div class="announce error">
+<div>
+One or more errors occured while processing the input you entered.
 </div>
 
+
+<span style='color:black'>
+<div>
+Please press the back button on your browser, correct the errors listed above and press the save button again.
+<br>
+If you do not see any error message listed above, or if the error messages do not make clear what the problem is,
+please help us to improve the website by <a href="{{ feedbackpage }}">reporting the problem</a>.
+</div>
+</span>
+</div>
 
 {% endblock %}

--- a/seminars/templates/inputerror.html
+++ b/seminars/templates/inputerror.html
@@ -1,0 +1,20 @@
+{% extends 'homepage.html' %}
+{% block content %}
+
+<div class="announce red">
+<div>Unable to save data</div>
+A problem occured while trying to save the input you entered:
+{% if messages %}
+<ul>
+{% for msg in messages %}
+<li>{{msg}}</li>
+{% endfor %}
+</ul>
+{% elif message %}
+<br>
+{{ message }}
+</div>
+
+Please press the back button on your browser, correct the problems noted above, then press save again.
+
+{% endblock %}

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, time, date
 from dateutil.parser import parse as parse_time
 import pytz, re, iso639
 from six import string_types
-from flask import url_for, flash
+from flask import url_for, flash, render_template
 from flask_login import current_user
 from seminars import db
 from sage.misc.cachefunc import cached_function

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -385,6 +385,19 @@ def process_user_input(inp, typ, tz):
         raise ValueError("Unrecognized type %s" % typ)
 
 
+def format_errmsg (errmsg, *args):
+    """ Foramts an error message prefixed by "Error" (so don't start your errmsg with the word error) in red text with arguments in black """
+    return Markup("Error: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)))
+
+def show_input_errors(errmsgs):
+    """ Flashes a list of specific user input error messages then displays a generic message telling the user to fix the problems and resubmit. """
+    assert errmsgs
+    for msg in errmsgs:
+        flash(msg,"error")
+    return render_template("inputerror.html",messages=errmsgs)
+
+
+
 def toggle(tglid, value, checked=False, classes="", onchange="", name=""):
     if classes:
         classes += " "


### PR DESCRIPTION
This PR fixes a bunch of user input validation errors.  Currently if you enter invalid data (e.g. the word "banana") into a time or numeric field a server error results.  With this PR an error should be flashed for each input error and the user is taken to a friendlier 500.html that tells them to press the back button, fix the problems, and press save again.  This avoids trying to create a WebSeminar or WebTalk object with bogus data that was causing all sorts of errors to show up in the flasklog.

You should now be able to type "banana" (or any other garbage string you choose) into any input field on the edit talk or edit seminar pages without getting a server error.  I also added validation for positive integers (like frequency and talks per day which you can currently make negative) and validation for the organizer list, such as requiring non-blank names and at least one email address.

Additionally this PR allows seminar organizers to have associated homepage URLs that will supersede their email address on the view seminar page.  This allows organizers whose contact information is obfuscated on their home page to preserve that protection.  The only situation where we will show an email address on a view seminar page is when no homepage is specified and the display box is checked.

Note to admins and curators -- please add homepages for all seminar organizers for seminars you have created once this PR is merged.

I also added knowls for the column headings of the seminar organizer table.  The knowl content can be edited by modifying knowls.yaml.

Once this PR is merged I will make similar fixes to the input validation on the edit schedule page.

