### PR TITLE
Cleanup time handling

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -367,6 +367,7 @@ def save_seminar():
             typ = "time"
         try:
             val = raw_data.get(col, "")
+            data[col] = None # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
         except Exception as err:
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
@@ -390,20 +391,16 @@ def save_seminar():
     for i in range(10):
         D = {"seminar_id": seminar.shortname}
         for col in db.seminar_organizers.search_cols:
-            print(D)
-            print("col: %s"%(col))
             if col in D:
                 continue
             name = "org_%s%s" % (col, i)
             typ = db.seminar_organizers.col_type[col]
             try:
                 val = raw_data.get(name, "")
-                print("col: %s, typ: %s, val: %s"%(val, col, typ))
+                D[col] = None # make sure col is present even if process_user_input fails
                 D[col] = process_user_input(val, col, typ, tz)
-                printf("D[%s] = %s"%(col,D[col]))
             except Exception as err:
                 errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
-        print(D)
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
                 errmsgs.append(format_errmsg("organizer %s cannot be blank", "name"))
@@ -503,6 +500,7 @@ def save_institution():
         typ = db.institutions.col_type[col]
         try:
             val = raw_data.get(col, "")
+            data[col] = None # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
             if col == "admin":
                 userdata = db.users.lookup(data[col])
@@ -612,6 +610,7 @@ def save_talk():
         typ = db.talks.col_type[col]
         try:
             val = raw_data.get(col, "")
+            data[col] = None # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
             if col == "access" and data[col] not in ["open", "users", "endorsed"]:
                 errmsgs.append(format_errmsg("access type %s invalid", data[col]))
@@ -875,6 +874,7 @@ def save_seminar_schedule():
             typ = db.talks.col_type[col]
             try:
                 val = raw_data.get("%s%s" % (col, i), "")
+                data[col] = None # make sure col is present even if process_user_input fails
                 data[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
                 errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -825,7 +825,7 @@ def save_seminar_schedule():
             except Exception as err: # should only be ValueError's but let's be cautious
                 errmsgs.append(format_errmsg("Unable to process input %s for date: {0}".format(err), date))
         else:
-            date = None
+            errmsgs.append(format_errmsg("You must specify a date for the talk by %s", speaker))
         time_input = raw_data.get("time%s" % i, "").strip()
         start_time = end_time = None
         if time_input:
@@ -838,14 +838,17 @@ def save_seminar_schedule():
                 if not time_split[0].strip() or not time_split[1].strip():
                     raise ValueError("You must specify both a start and end time.")
                 # TODO: clean this up
-                start_time = process_user_input(time_split[0], "start_time", "time", tz).time()
-                end_time = process_user_input(time_split[1], "end_time", "time", tz).time()
+                start_time = process_user_input(time_split[0], "start_time", "time", tz)
+                end_time = process_user_input(time_split[1], "end_time", "time", tz)
             except Exception as err:
                 errmsgs.append(format_errmsg("Unable to process input %s for time: {0}".format(err), time_input,))
-        if any(X is None for X in [start_time, end_time, date]):
-            errmsgs.append(format_errmsg("You must give a date, start, and end time for %s", speaker))
+        if any(X is None for X in [start_time, end_time]):
+            errmsgs.append(format_errmsg("You must specify a start and end time for the talk by speaker %s", speaker))
+        else:
+            start_time = start_time.time()
+            end_time = end_time.time()
 
-        # we need to flag date and time errors now
+        # we need to flag date and time errors before we go any further
         if errmsgs:
             return show_input_errors(errmsgs)
 

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -396,6 +396,7 @@ def save_seminar():
             typ = db.seminar_organizers.col_type[col]
             try:
                 val = raw_data.get(name, "")
+                print("col: %s, typ: %s, val: %s"%(val, col, typ))
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
                 errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -390,6 +390,8 @@ def save_seminar():
     for i in range(10):
         D = {"seminar_id": seminar.shortname}
         for col in db.seminar_organizers.search_cols:
+            print(D)
+            print("col: %s"%(col))
             if col in D:
                 continue
             name = "org_%s%s" % (col, i)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -832,11 +832,11 @@ def save_seminar_schedule():
             try:
                 time_split = time_input.split("-")
                 if len(time_split) < 2:
-                    raise ValueError("You specify both a start and end time.")
+                    raise ValueError("Invalid time range.")
                 elif len(time_split) > 2:
                     raise ValueError("Time range contains more than one hyphen, expected hh:mm-hh:mm.")
                 if not time_split[0].strip() or not time_split[1].strip():
-                    raise ValueError("You must specify both a start and end time.")
+                    raise ValueError("Invalid time range.")
                 # TODO: clean this up
                 start_time = process_user_input(time_split[0], "start_time", "time", tz)
                 end_time = process_user_input(time_split[1], "end_time", "time", tz)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -400,6 +400,7 @@ def save_seminar():
                 val = raw_data.get(name, "")
                 print("col: %s, typ: %s, val: %s"%(val, col, typ))
                 D[col] = process_user_input(val, col, typ, tz)
+                printf("D[%s] = %s"%(col,D[col]))
             except Exception as err:
                 errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
         print(D)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -399,6 +399,7 @@ def save_seminar():
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
                 errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
+        print D
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
                 errmsgs.append(format_errmsg("organizer %s cannot be blank", "name"))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -399,7 +399,7 @@ def save_seminar():
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
                 errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
-        print D
+        print(D)
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
                 errmsgs.append(format_errmsg("organizer %s cannot be blank", "name"))

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -351,6 +351,8 @@ def process_user_input(inp, col, typ, tz):
         # a datetime object with the date set to today.  This could cause different
         # relative orders around daylight savings time, so we store all times
         # as datetimes on Jan 1, 2020.
+        if inp.isdigit():
+            inp += ":00"  # treat numbers as times not dates
         t = parse_time(inp)
         t = t.replace(year=2020, month=1, day=1)
         return localize_time(t, tz)


### PR DESCRIPTION
Fix a bug when end time is not specified and handle numbers as times not dates
(currently entering 10-11 in the schedule creates a talk from 00:00 to 00:00 because 10 and 11 are interpreted as dates and we then strip the date away, with this PR 10-11 produces 10:00-11:00)
