### PR TITLE
Make sure seminars have start and end times

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -519,6 +519,8 @@ def save_institution():
     if errmsgs:
         return show_input_errors(errmsgs)
     new_version = WebInstitution(shortname, data=data)
+    print(institution)
+    print(new_version)
     if new_version == institution:
         flash("No changes made to institution.")
     else:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -623,11 +623,13 @@ def save_talk():
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     if not data["speaker"]:
         errmegs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
-    data["topics"] = clean_topics(data.get("topics"))
-    data["language"] = clean_language(data.get("language"))
+    if data["start_time"] is None or data["end_time"] is None:
+        errmsg.append("Talks must have both a start and end time.")
     # Don't try to create new_version using invalid input
     if errmsgs:
         return show_input_errors(errmsgs)
+    data["topics"] = clean_topics(data.get("topics"))
+    data["language"] = clean_language(data.get("language"))
     new_version = WebTalk(talk.seminar_id, data["seminar_ctr"], data=data)
     sanity_check_times(new_version.start_time, new_version.end_time)
     if new_version == talk:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -519,8 +519,9 @@ def save_institution():
     if errmsgs:
         return show_input_errors(errmsgs)
     new_version = WebInstitution(shortname, data=data)
-    print(data)
-    print(institution)
+    ### FIXME ###
+    # The comparison below always fails because can_edit_institution returns a dictionary
+    # see FIXME at line 110 of institution.py
     if new_version == institution:
         flash("No changes made to institution.")
     else:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -339,7 +339,6 @@ def save_seminar():
     resp, seminar = can_edit_seminar(shortname, new)
     if resp is not None:
         return resp
-    print(type(seminar))
     errmsgs = []
 
     if seminar.new:
@@ -490,7 +489,6 @@ def save_institution():
     resp, institution = can_edit_institution(shortname, new)
     if resp is not None:
         return resp
-    print(type(institution))
 
     data = {}
     data["timezone"] = tz = raw_data.get("timezone", "UTC")
@@ -521,8 +519,8 @@ def save_institution():
     if errmsgs:
         return show_input_errors(errmsgs)
     new_version = WebInstitution(shortname, data=data)
-    print(type(institution))
-    print(new_version)
+    print(data)
+    print(institution)
     if new_version == institution:
         flash("No changes made to institution.")
     else:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -622,9 +622,9 @@ def save_talk():
         except Exception as err: # should only be ValueError's but let's be cautious
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     if not data["speaker"]:
-        errmegs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
+        errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:
-        errmsg.append("Talks must have both a start and end time.")
+        errmsgs.append("Talks must have both a start and end time.")
     # Don't try to create new_version using invalid input
     if errmsgs:
         return show_input_errors(errmsgs)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -507,7 +507,7 @@ def save_institution():
                 if userdata is None:
                     if not data[col]:
                         errmsgs.append("You must specify the email address of the maintainer.")
-                    else
+                    else:
                         errmsgs.append(format_errmsg("user %s does not have an account on this site", data[col]))
                 elif not userdata["creator"]:
                     errmsgs.append(format_errmsg("user %s has not been endorsed", data[col]))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -339,6 +339,7 @@ def save_seminar():
     resp, seminar = can_edit_seminar(shortname, new)
     if resp is not None:
         return resp
+    print(type(seminar))
     errmsgs = []
 
     if seminar.new:
@@ -489,6 +490,7 @@ def save_institution():
     resp, institution = can_edit_institution(shortname, new)
     if resp is not None:
         return resp
+    print(type(institution))
 
     data = {}
     data["timezone"] = tz = raw_data.get("timezone", "UTC")
@@ -519,7 +521,7 @@ def save_institution():
     if errmsgs:
         return show_input_errors(errmsgs)
     new_version = WebInstitution(shortname, data=data)
-    print(institution)
+    print(type(institution))
     print(new_version)
     if new_version == institution:
         flash("No changes made to institution.")

--- a/seminars/institution.py
+++ b/seminars/institution.py
@@ -106,7 +106,8 @@ class WebInstitution(object):
             userdata["name"] if userdata["name"] else self.admin,
         )
 
-
+### FIXME ###
+# Should always return a WebInstitution object but currently may returna dictionary or WebObject
 def can_edit_institution(shortname, new):
     if not allowed_shortname(shortname):
         flash_error(

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -495,7 +495,6 @@ def can_edit_seminar(shortname, new):
         )
         return redirect(url_for(".index"), 302), None
     seminar = seminars_lookup(shortname, include_deleted=True)
-    print(type(seminar))
     # Check if seminar exists
     if new != (seminar is None):
         if seminar is not None and seminar.deleted:
@@ -526,5 +525,4 @@ def can_edit_seminar(shortname, new):
         return redirect(url_for(".index"), 302), None
     if seminar is None:
         seminar = WebSeminar(shortname, data=None, editing=True)
-    print(type(seminar))
     return None, seminar

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -495,6 +495,7 @@ def can_edit_seminar(shortname, new):
         )
         return redirect(url_for(".index"), 302), None
     seminar = seminars_lookup(shortname, include_deleted=True)
+    print(type(seminar))
     # Check if seminar exists
     if new != (seminar is None):
         if seminar is not None and seminar.deleted:
@@ -525,4 +526,5 @@ def can_edit_seminar(shortname, new):
         return redirect(url_for(".index"), 302), None
     if seminar is None:
         seminar = WebSeminar(shortname, data=None, editing=True)
+    print(type(seminar))
     return None, seminar


### PR DESCRIPTION
To avoid server errors in view semianr, we need talks to always have both start and end times.  There are no longer any in the database and this PR prevents users from leaving start or end time blank.

Also note FIXME in can_edit_institution, which should be fixed in a later PR -- the comparison between new_version and institution is broken becase can_edit_institution is returning a dictionary rather than a WebInstitution object.