### PR TITLE
Resolves #10

### DIFF
--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -129,10 +129,10 @@ class WebSeminar(object):
     def tz(self):
         return pytz.timezone(self.timezone)
 
-    def show_day(self, truncate=True):
+    def show_day(self, truncate=True, adapt=True):
         if self.weekday is None:
             return ""
-        elif self.start_time is None:
+        elif self.start_time is None or not adapt:
             d = weekdays[self.weekday]
         else:
             d = weekdays[adapt_weektime(self.start_time, self.tz, weekday=self.weekday)[0]]
@@ -157,7 +157,7 @@ class WebSeminar(object):
         return self._show_time(self.end_time, adapt)
 
     def show_weektime_and_duration(self, adapt=True):
-        s = self.show_day(truncate=False)
+        s = self.show_day(truncate=False,adapt=adapt)
         if s:
             s += ", "
         s += self.show_start_time(adapt=adapt)

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -153,7 +153,7 @@ class WebTalk(object):
         else:
             return adapt_datetime(self.start_time, newtz=tz).strftime("%a %b %-d")
 
-    def show_time_and_duration(self):
+    def show_time_and_duration(self, adapt=True):
         start = self.start_time
         end = self.end_time
         now = datetime.datetime.now(pytz.utc)
@@ -164,11 +164,12 @@ class WebTalk(object):
         week = delta(weeks=1)
         month = delta(days=30.4)
         year = delta(days=365)
+        newtz = None if adapt else self.tz
 
         def ans(rmk):
             return "%s-%s (%s)" % (
-                adapt_datetime(start).strftime("%a %b %-d, %H:%M"),
-                adapt_datetime(end).strftime("%H:%M"),
+                adapt_datetime(start, newtz=newtz).strftime("%a %b %-d, %H:%M"),
+                adapt_datetime(end, newtz=newtz).strftime("%H:%M"),
                 rmk,
             )
 

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -53,7 +53,7 @@ class WebTalk(object):
             self.token = "%016x" % random.randrange(16 ** 16)
             self.display = seminar.display
             self.online = getattr(seminar, "online", bool(seminar.live_link))
-            self.tz = seminar.tz
+            self.timezone = seminar.timezone
             for key, typ in db.talks.col_type.items():
                 if key == "id" or hasattr(self, key):
                     continue

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -27,6 +27,7 @@ class WebTalk(object):
         semctr=None,
         data=None,
         seminar=None,
+        tz=None,
         editing=False,
         showing=False,
         saving=False,
@@ -53,6 +54,7 @@ class WebTalk(object):
             self.token = "%016x" % random.randrange(16 ** 16)
             self.display = seminar.display
             self.online = getattr(seminar, "online", bool(seminar.live_link))
+            self.tz = seminar.tz
             for key, typ in db.talks.col_type.items():
                 if key == "id" or hasattr(self, key):
                     continue
@@ -69,11 +71,11 @@ class WebTalk(object):
         else:
             # The output from psycopg2 seems to always be given in the server's time zone
             if data.get("timezone"):
-                tz = pytz.timezone(data["timezone"])
+                self.tz = pytz.timezone(data["timezone"])
                 if data.get("start_time"):
-                    data["start_time"] = adapt_datetime(data["start_time"], tz)
+                    data["start_time"] = adapt_datetime(data["start_time"], self.tz)
                 if data.get("end_time"):
-                    data["end_time"] = adapt_datetime(data["end_time"], tz)
+                    data["end_time"] = adapt_datetime(data["end_time"], self.tz)
             self.__dict__.update(data)
 
     def __repr__(self):

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -27,7 +27,6 @@ class WebTalk(object):
         semctr=None,
         data=None,
         seminar=None,
-        tz=None,
         editing=False,
         showing=False,
         saving=False,
@@ -71,11 +70,11 @@ class WebTalk(object):
         else:
             # The output from psycopg2 seems to always be given in the server's time zone
             if data.get("timezone"):
-                self.tz = pytz.timezone(data["timezone"])
+                tz = pytz.timezone(data["timezone"])
                 if data.get("start_time"):
-                    data["start_time"] = adapt_datetime(data["start_time"], self.tz)
+                    data["start_time"] = adapt_datetime(data["start_time"], tz)
                 if data.get("end_time"):
-                    data["end_time"] = adapt_datetime(data["end_time"], self.tz)
+                    data["end_time"] = adapt_datetime(data["end_time"], tz)
             self.__dict__.update(data)
 
     def __repr__(self):
@@ -124,6 +123,10 @@ class WebTalk(object):
         A version of the start time for editing
         """
         return self._editable_time(self.end_time)
+
+    @property
+    def tz(self):
+        return pytz.timezone(self.timezone)
 
     def show_start_time(self, tz=None):
         return adapt_datetime(self.start_time, tz).strftime("%H:%M")

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -30,9 +30,9 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}
-     {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }} {% endif %}.</p>
-  {% if seminar.timezone and seminar.timezeon != current_user.timezone %}
-    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in the seminar's time zone, {{ seminar.timezone.replace("_", " ") }}.</p>
+     {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
+  {% if seminar.timezone and seminar.timezone != current_user.timezone %}
+    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " "). }}</p>
   {% endif %}
 {% endif %}
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -30,7 +30,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% if seminar.timezone != current_user.timezone %}
+  {% if not seminar.online and seminar.timezone != current_user.timezone %}
     <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " ") }}.</p>
   {% endif %}
 {% endif %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -30,7 +30,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% if not seminar.online and seminar.timezone != current_user.timezone %}
+  {% if (not seminar.online or seminar.room) and seminar.timezone != current_user.timezone %}
     <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " ") }}.</p>
   {% endif %}
 {% endif %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,8 +31,6 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}
      {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% if seminar.timezone != current_user.timezone %} 
-    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " "). }}</p>
   {% endif %}
 {% endif %}
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -29,8 +29,10 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% endif %}
 
 {% if seminar.weekday is not none or seminar.start_time %}
-  <p>{{ seminar.show_weektime_and_duration() }}
-     {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
+  <p>{{ seminar.show_weektime_and_duration() }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
+  {% if seminar.timezone != current_user.timezone %}
+    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " ") }}. {% endif %}</p>
+  {% endif %}
 {% endif %}
 
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,7 +31,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}
      {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% if seminar.timezone and seminar.timezone != current_user.timezone %}
+  {% if seminar.timezone != current_user.timezone %}
     <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " "). }}</p>
   {% endif %}
 {% endif %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -26,9 +26,16 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>
     Description: {{(seminar.description | blanknone) + seminar.show_topics() | safe }}
   </p>
- {% endif %}
+{% endif %}
 
-{% if seminar.weekday is not none or seminar.start_time %}<p>{{ seminar.show_weektime_and_duration() }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.{% endif %}</p>{% endif %}
+{% if seminar.weekday is not none or seminar.start_time %}
+  <p>{{ seminar.show_weektime_and_duration() }}
+     {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }} {% endif %}.</p>
+  {% if seminar.timezone and seminar.timezeon != current_user.timezone %}
+    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in the seminar's time zone, {{ seminar.timezone.replace("_", " ") }}.</p>
+  {% endif %}
+{% endif %}
+
 
 {% if seminar.homepage %}
 <p>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,7 +31,6 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}
      {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% endif %}
 {% endif %}
 
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,7 +31,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
   {% if seminar.timezone != current_user.timezone %}
-    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " ") }}. {% endif %}</p>
+    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " ") }}.</p>
   {% endif %}
 {% endif %}
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,7 +31,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.weekday is not none or seminar.start_time %}
   <p>{{ seminar.show_weektime_and_duration() }}
      {% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% if seminar.timezone != current_user.timezone %}
+  {% if seminar.timezone != current_user.timezone %} 
     <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in seminar time zone, {{ seminar.timezone.replace("_", " "). }}</p>
   {% endif %}
 {% endif %}

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -26,6 +26,10 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   <p>
     {{ talk.show_time_and_duration() | safe }}{% if talk.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.{% endif %}
   </p>
+  {% if talk.timezone != current_user.timezone %}
+    <p>{{ talk.show_time_and_duration(adapt=False) | safe }} in talk time zone, {{ talk.timezone.replace("_", " ") }}.</p>
+  {% endif %}
+
 
   <p>
     {{ talk.show_live_link() | safe }}

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -26,7 +26,7 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   <p>
     {{ talk.show_time_and_duration() | safe }}{% if talk.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.{% endif %}
   </p>
-  {% if not talk.online and talk.timezone != current_user.timezone %}
+  {% if (not talk.online or talk.room) and talk.timezone != current_user.timezone %}
     <p>{{ talk.show_time_and_duration(adapt=False) | safe }} in talk time zone, {{ talk.timezone.replace("_", " ") }}.</p>
   {% endif %}
 

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -26,7 +26,7 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   <p>
     {{ talk.show_time_and_duration() | safe }}{% if talk.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.{% endif %}
   </p>
-  {% if talk.timezone != current_user.timezone %}
+  {% if not talk.online and talk.timezone != current_user.timezone %}
     <p>{{ talk.show_time_and_duration(adapt=False) | safe }} in talk time zone, {{ talk.timezone.replace("_", " ") }}.</p>
   {% endif %}
 


### PR DESCRIPTION
On View seminar and View talk pages shows the meeting time both in the users time zone and the seminar time zone if they are different.  This can happen when the times are actually the same (e.g. US/Eastern and America/New York), which is slightly annoying but at least not confusing.