### PR TITLE
Resolves #102 and makes other UI improvements

### DIFF
--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -27,63 +27,53 @@
         <input type="hidden" name="is_conference" value="{% if seminar.is_conference %}yes{% else %}no{% endif %}"/>
       <table>
         <tr>
-          <td>
-            Identifier
-          </td>
-          <td>
-            {{ seminar.shortname }}
-          </td>
+          <td style="width:150px;">Identifier</td>
+          <td>{{ seminar.shortname }}</td>
         </tr>
         <tr>
           <td>Full name</td>
-          <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:500px;" /></td>
+          <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" /></td>
           <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
         </tr>
         <tr>
           <td>Short description</td>
-          <td><input name="description" value="{{ seminar.description | blanknone }}" style="width:500px;" placeholder="research seminar" maxlength="60"/></td>
+          <td><input name="description" value="{{ seminar.description | blanknone }}" style="width:600px;" placeholder="research seminar" maxlength="60"/></td>
         </tr>
         <tr>
           <td style="white-space:nowrap">External homepage</td>
-          <td><input style="width:500px;" name="homepage" value="{{ seminar.homepage | blanknone }}" placeholder="https://example.org"/></td>
-        </tr>
-        <tr>
-          <td>Topics</td>
-          <td>
-            <span id="topic_selector"></span>
-          </td>
+          <td><input name="homepage" value="{{ seminar.homepage | blanknone }}" style="width:600px;" placeholder="https://example.org"/></td>
         </tr>
         <tr>
           <td>Institutions</td>
-          <td>
-            <span id="institution_selector"></span>
-          </td>
+          <td><span id="institution_selector" style="width:600px;"></span></td>
+        </tr>
+        <tr>
+          <td>Topics</td>
+          <td><span id="topic_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
           <td>Default language</td>
-          <td>
-            <span id="language_selector"></span>
-          </td>
+          <td><span id="language_selector" style="width:600px;"></span></td>
         </tr>
 
         {% if seminar.is_conference %}
         <tr>
           <td style="padding-top: 20px">Start date</td>
           <td style="padding-top: 20px">
-            <input name="start_date" style="width:500px;" value="{{ seminar.show_input_date(seminar.start_date) }}" placeholder="2020-01-27" />
+            <input name="start_date" style="width:600px;" value="{{ seminar.show_input_date(seminar.start_date) }}" style="width:600px;" placeholder="2020-01-27" />
           </td>
         </tr>
         <tr>
           <td>End date</td>
           <td>
-            <input name="end_date" style="width:500px;" value="{{ seminar.show_input_date(seminar.end_date) }}" placeholder="2020-01-31" />
+            <input name="end_date" value="{{ seminar.show_input_date(seminar.end_date) }}" style="width:600px;" placeholder="2020-01-31" />
           </td>
         </tr>
         {% else %}
         <tr>
           <td style="padding-top: 20px">Meeting day</td>
           <td style="padding-top: 20px">
-            <select name="weekday" style="width:510px;">
+            <select name="weekday" style="width:610px;">
               <option value=""></option>
               {% for wkday in weekdays %}
                 <option value="{{loop.index0}}"{% if seminar.weekday == loop.index0 %} selected{% endif %}>{{wkday}}</option>
@@ -93,17 +83,18 @@
         </tr>
         <tr>
           <td style="white-space:nowrap">Frequency (in days)</td>
-          <td><input name="frequency" style="width:500px;" value="{{ seminar.frequency | blanknone }}" /></td>
+          <td><input name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:600px;"/></td>
         </tr>
         {% endif %}
+
         <tr>
           <td>Talks per day</td>
-          <td><input name="per_day" style="width:500px;" value="{{ seminar.per_day | blanknone }}" /></td>
+          <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:500px;" /></td>
         </tr>
         <tr>
           <td>Time zone</td>
           <td>
-            <select name="timezone" style="width:510px;">
+            <select name="timezone" style="width:610px;">
               {% for tz, disp in timezones %}
                 <option value="{{ tz }}"{% if seminar.timezone == tz %} selected{% endif %}>{{disp}}</option>
               {% endfor %}
@@ -113,21 +104,21 @@
         {% if not seminar.is_conference %}
         <tr>
           <td>Start time</td>
-          <td><input name="start_time" style="width:500px;" value="{{ seminar.show_input_time(seminar.start_time) }}" placeholder="15:00"/></td>
+          <td><input name="start_time" value="{{ seminar.show_input_time(seminar.start_time) }}" style="width:600px;" placeholder="15:00"/></td>
         </tr>
         <tr>
           <td>End time</td>
-          <td><input name="end_time" style="width:500px;" value="{{ seminar.show_input_time(seminar.end_time) }}" placeholder="16:00"/></td>
+          <td><input name="end_time" value="{{ seminar.show_input_time(seminar.end_time) }}" style="width:600px;" placeholder="16:00"/></td>
         </tr>
         {% endif %}
         <tr>
           <td style="padding-top: 20px">Room</td>
-          <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:500px;" /></td>
+          <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>
           <td>Online</td>
           <td>
-            <select name="online" style="width:510px;">
+            <select name="online" style="width:610px;">
               <option value="yes"{% if seminar.online %} selected{% endif %}>yes</option>
               <option value="no"{% if not seminar.online %} selected{% endif %}>no</option>
             </select>
@@ -135,13 +126,13 @@
         </tr>
         <tr>
           <td>Livestream link</td>
-          <td><input name="live_link" value="{{ seminar.live_link | blanknone }}" style="width:500px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
+          <td><input name="live_link" value="{{ seminar.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the comments how to get the link.</td>
         </tr>
         <tr>
           <td>Access</td>
           <td>
-            <select name="access" style="width:510px;">
+            <select name="access" style="width:610px;">
               <option value="open"{% if seminar.access == 'open' %} selected{% endif %}>All visitors can view link</option>
               <option value="users"{% if seminar.access == 'users' %} selected{% endif %}>Only logged-in users can view link</option>
               <option value="endorsed"{% if seminar.access == 'endorsed' %} selected{% endif %}>Only endorsed users can view link</option>
@@ -163,7 +154,7 @@
           <td colspan="2" style="padding-top: 10px">Comments</td>
         </tr>
         <tr>
-          <td colspan="2"><textarea cols="76" rows="7" name="comments">{{ seminar.comments | blanknone }}</textarea></td>
+          <td colspan="2"><textarea cols="89" rows="6" style="width:770px;" name="comments">{{ seminar.comments | blanknone }}</textarea></td>
         </tr>
       </table>
       <h3>Organizers</h3>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -163,7 +163,7 @@
           <td colspan="2" style="padding-top: 10px">Comments</td>
         </tr>
         <tr>
-          <td colspan="2"><textarea cols="76" rows="5" name="comments">{{ seminar.comments | blanknone }}</textarea></td>
+          <td colspan="2"><textarea cols="76" rows="7" name="comments">{{ seminar.comments | blanknone }}</textarea></td>
         </tr>
       </table>
       <h3>Organizers</h3>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -127,7 +127,7 @@
         <tr>
           <td>Livestream link</td>
           <td><input name="live_link" value="{{ seminar.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
-          <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the comments how to get the link.</td>
+          <td class="forminfo" />Enter "see comments" if link is not fixed and explain in comments how to the link.</td>
         </tr>
         <tr>
           <td>Access</td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -45,7 +45,7 @@
         </tr>
         <tr>
           <td>Institutions</td>
-          <td><span id="institution_selector" style="width:600px;"></span></td>
+          <td><span id="institution_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
           <td>Topics</td>
@@ -89,7 +89,7 @@
 
         <tr>
           <td>Talks per day</td>
-          <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:500px;" /></td>
+          <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>
           <td>Time zone</td>
@@ -143,7 +143,7 @@
           <tr>
             <td>Archived</td>
             <td>
-              <select name="archived" style="width:510px;">
+              <select name="archived" style="width:610px;">
                 <option value="yes"{% if seminar.archived %} selected{% endif %}>yes</option>
                 <option value="no"{% if not seminar.archived %} selected{% endif %}>no</option>
               </select>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="96" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="90" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">
@@ -126,7 +126,7 @@
   <table>
     <tr>
       <td colspan="2">
-        <textarea cols="76" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
+        <textarea cols="90" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
       </td>
     </tr>
   </table>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -16,7 +16,7 @@
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
   <table>
     <tr>
-      <td sytle="width:200px;">Seminar</td>
+      <td style="width:200px;">Seminar</td>
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -16,9 +16,7 @@
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
   <table>
     <tr>
-      <td>
-        Seminar
-      </td>
+      <td sytle="width:200px;">Seminar</td>
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -16,7 +16,7 @@
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
   <table>
     <tr>
-      <td style="width:200px;">Seminar</td>
+      <td style="width:100px;">Seminar</td>
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>
@@ -24,7 +24,7 @@
     <tr>
       <td>Topics</td>
       <td>
-        <span id="topic_selector" style="width:600px;"></span>
+        <span id="topic_selector" style="width:610px;"></span>
       </td>
     </tr>
     <tr>
@@ -36,7 +36,7 @@
     <tr>
       <td>Time zone</td>
       <td>
-        <select name="timezone" style="width:600px;">
+        <select name="timezone" style="width:610px;">
           {% for tz, disp in timezones %}
           <option value="{{ tz }}"{% if talk.timezone == tz %} selected{% endif %}>{{disp}}</option>
           {% endfor %}
@@ -58,7 +58,7 @@
     <tr>
       <td>Online</td>
       <td>
-        <select name="online" style="width:600px;">
+        <select name="online" style="width:610px;">
           <option value="yes"{% if talk.online %} selected{% endif %}>yes</option>
           <option value="no"{% if not talk.online %} selected{% endif %}>no</option>
         </select>
@@ -72,7 +72,7 @@
     <tr>
       <td>Access</td>
       <td>
-        <select name="access" style="width:600px;">
+        <select name="access" style="width:610px;">
           <option value="open"{% if talk.access == 'open' %} selected{% endif %}>All visitors can view link</option>
           <option value="users"{% if talk.access == 'users' %} selected{% endif %}>Only logged-in users can view link</option>
           <option value="endorsed"{% if talk.access == 'endorsed' %} selected{% endif %}>Only endorsed users can view link</option>
@@ -83,13 +83,13 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="76" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="100" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
-  <hr style="width: 700px;">
+  <hr style="width:800px;">
   <table>
     <tr>
-      <td>Speaker</td>
+      <td style="width:200px">Speaker</td>
       <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -126,7 +126,7 @@
   <table>
     <tr>
       <td colspan="2">
-        <textarea cols="89" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
+        <textarea cols="89" rows="10" style="width:770px;"  name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
       </td>
     </tr>
   </table>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -16,7 +16,7 @@
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
   <table>
     <tr>
-      <td style="width:100px;">Seminar</td>
+      <td style="width:150px;">Seminar</td>
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>
@@ -83,13 +83,13 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="100" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="96" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">
   <table>
     <tr>
-      <td style="width:200px">Speaker</td>
+      <td style="width:150px">Speaker</td>
       <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Only put talk specific comments here such as specific livestream access instructions for this talk or notes about the speaker; seminar comments will appear immediately after whatever you type here.">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; seminar comments will appear immediately after talk comments.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="5" style="width:750px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -156,7 +156,7 @@
 
 <div id="view-wrapper" class="knowl" style="width:670px;">
   <div id="view-preview">
-    <h1 id="view-title"></h1>
+    <h2 id="view-title"></h2>
     <div id="view-abstract"></div>
   </div>
 </div>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -51,15 +51,15 @@
     </tr>
     <tr>
       <td>Start</td>
-      <td><input name="start_time" value="{{ talk.editable_start_time() }}" style="width:500px;" /></td>
+      <td><input name="start_time" value="{{ talk.editable_start_time() }}"/></td>
     </tr>
     <tr>
       <td>End</td>
-      <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:500px;" /></td>
+      <td><input name="end_time" value="{{ talk.editable_end_time() }}" /></td>
     </tr>
     <tr>
       <td>Room</td>
-      <td><input name="room" value="{{ talk.room | blanknone }}" style="width:500px;" /></td>
+      <td><input name="room" value="{{ talk.room | blanknone }}" /></td>
     </tr>
     <tr>
       <td>Online</td>
@@ -71,7 +71,7 @@
       </td>
     </tr>
     <tr>
-      <td>Livestream link</td>
+      <td>Live link</td>
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:500px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the seminar or talk comments how to get the link.</td>
     </tr>
@@ -93,18 +93,22 @@
     </tr>
   </table>
   <hr style="width: 700px;">
-  <table>
+  <table style="width: 100%">
+    <colgroup>
+      <col span="1" style="width: 20%;">
+      <col span="1" style="width: 80%;">
+    </colgroup>
     <tr>
       <td>Speaker</td>
-      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:500px;" /></td>
+      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" /></td>
     </tr>
     <tr>
       <td>Speaker email</td>
-      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:500px;" /></td>
+      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" /></td>
     </tr>
     <tr>
       <td>Speaker affiliation</td>
-      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:500px;" /></td>
+      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" /></td>
     </tr>
     <tr>
       <td>Speaker homepage</td>
@@ -112,20 +116,20 @@
     </tr>
     <tr>
       <td>Title</td>
-      <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:500px;" placeholder="TeX symbols are OK here" /></td>
+      <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" placeholder="TeX symbols are OK here" /></td>
       <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
     </tr>
     <tr>
       <td>Paper link</td>
-      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:500px;" /></td>
+      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" /></td>
     </tr>
     <tr>
       <td>Slides link</td>
-      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:500px;" /></td>
+      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" /></td>
     </tr>
     <tr>
       <td>Video link</td>
-      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:500px;" /></td>
+      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" /></td>
     </tr>
   </table>
   <h3>Abstract</h3>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Only put talk specific comments here such as specific livestream access instructions for this talk or notes about the speaker; seminar comments will appear immediately after whatever you type here.>{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Only put talk specific comments here such as specific livestream access instructions for this talk or notes about the speaker; seminar comments will appear immediately after whatever you type here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -14,11 +14,7 @@
   <input type="hidden" name="token" value="{{ talk.token }}"/>
   <input type="hidden" name="topics" value="{{ talk.topics | safe }}"/>
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
-  <table style="width: 100%">
-    <colgroup>
-      <col span="1" style="width: 20%;">
-      <col span="1" style="width: 80%;">
-    </colgroup>
+  <table>
     <tr>
       <td>
         Seminar
@@ -30,19 +26,19 @@
     <tr>
       <td>Topics</td>
       <td>
-        <span id="topic_selector"></span>
+        <span id="topic_selector" style="width:600px;"></span>
       </td>
     </tr>
     <tr>
       <td>Language</td>
       <td>
-        <span id="language_selector"></span>
+        <span id="language_selector" style="width:600px;"></span>
       </td>
     </tr>
     <tr>
       <td>Time zone</td>
       <td>
-        <select name="timezone">
+        <select name="timezone" style="width:600px;">
           {% for tz, disp in timezones %}
           <option value="{{ tz }}"{% if talk.timezone == tz %} selected{% endif %}>{{disp}}</option>
           {% endfor %}
@@ -51,20 +47,20 @@
     </tr>
     <tr>
       <td>Start</td>
-      <td><input name="start_time" value="{{ talk.editable_start_time() }}"/></td>
+      <td><input name="start_time" value="{{ talk.editable_start_time() }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>End</td>
-      <td><input name="end_time" value="{{ talk.editable_end_time() }}" /></td>
+      <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Room</td>
-      <td><input name="room" value="{{ talk.room | blanknone }}" /></td>
+      <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Online</td>
       <td>
-        <select name="online" style="width:510px;">
+        <select name="online" style="width:600px;">
           <option value="yes"{% if talk.online %} selected{% endif %}>yes</option>
           <option value="no"{% if not talk.online %} selected{% endif %}>no</option>
         </select>
@@ -72,13 +68,13 @@
     </tr>
     <tr>
       <td>Live link</td>
-      <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:500px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
+      <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the seminar or talk comments how to get the link.</td>
     </tr>
     <tr>
       <td>Access</td>
       <td>
-        <select name="access" style="width:510px;">
+        <select name="access" style="width:600px;">
           <option value="open"{% if talk.access == 'open' %} selected{% endif %}>All visitors can view link</option>
           <option value="users"{% if talk.access == 'users' %} selected{% endif %}>Only logged-in users can view link</option>
           <option value="endorsed"{% if talk.access == 'endorsed' %} selected{% endif %}>Only endorsed users can view link</option>
@@ -93,50 +89,46 @@
     </tr>
   </table>
   <hr style="width: 700px;">
-  <table style="width: 100%">
-    <colgroup>
-      <col span="1" style="width: 20%;">
-      <col span="1" style="width: 80%;">
-    </colgroup>
+  <table>
     <tr>
       <td>Speaker</td>
-      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" /></td>
+      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Speaker email</td>
-      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" /></td>
+      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Speaker affiliation</td>
-      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" /></td>
+      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Speaker homepage</td>
-      <td><input style="width:500px;" name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" /></td>
+      <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Title</td>
-      <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" placeholder="TeX symbols are OK here" /></td>
+      <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" placeholder="TeX symbols are OK here" /></td>
       <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
     </tr>
     <tr>
       <td>Paper link</td>
-      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" /></td>
+      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Slides link</td>
-      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" /></td>
+      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
       <td>Video link</td>
-      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" /></td>
+      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" /></td>
     </tr>
   </table>
   <h3>Abstract</h3>
   <table>
     <tr>
       <td colspan="2">
-        <textarea cols="80" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
+        <textarea cols="76" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
       </td>
     </tr>
   </table>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -26,19 +26,19 @@
     <tr>
       <td>Topics</td>
       <td>
-        <span id="topic_selector"></span>
+        <span id="topic_selector" style="width:600px;"></span>
       </td>
     </tr>
     <tr>
       <td>Language</td>
       <td>
-        <span id="language_selector"></span>
+        <span id="language_selector" style="width:600px;"></span>
       </td>
     </tr>
     <tr>
       <td>Time zone</td>
       <td>
-        <select name="timezone" style="width:510px;">
+        <select name="timezone" style="width:600px;">
           {% for tz, disp in timezones %}
           <option value="{{ tz }}"{% if talk.timezone == tz %} selected{% endif %}>{{disp}}</option>
           {% endfor %}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -82,10 +82,6 @@
       </td>
     </tr>
     <tr>
-      <td>Videorecording link</td>
-      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:500px;" /></td>
-    </tr>
-    <tr>
       <td colspan="2">Comments</td>
     </tr>
     <tr>
@@ -116,12 +112,16 @@
       <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
     </tr>
     <tr>
+      <td>Paper link</td>
+      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:500px;" /></td>
+    </tr>
+    <tr>
       <td>Slides link</td>
       <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:500px;" /></td>
     </tr>
     <tr>
-      <td>Paper link</td>
-      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:500px;" /></td>
+      <td>Video link</td>
+      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:500px;" /></td>
     </tr>
   </table>
   <h3>Abstract</h3>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Only put talk specific comments here such as specific livestream access instructions for this talk or notes about the speaker; seminar comments will appear immediately after whatever you type here.>{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -14,7 +14,11 @@
   <input type="hidden" name="token" value="{{ talk.token }}"/>
   <input type="hidden" name="topics" value="{{ talk.topics | safe }}"/>
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
-  <table>
+  <table style="width: 100%">
+    <colgroup>
+      <col span="1" style="width: 20%;">
+      <col span="1" style="width: 80%;">
+    </colgroup>
     <tr>
       <td>
         Seminar
@@ -26,19 +30,19 @@
     <tr>
       <td>Topics</td>
       <td>
-        <span id="topic_selector" style="width:600px;"></span>
+        <span id="topic_selector"></span>
       </td>
     </tr>
     <tr>
       <td>Language</td>
       <td>
-        <span id="language_selector" style="width:600px;"></span>
+        <span id="language_selector"></span>
       </td>
     </tr>
     <tr>
       <td>Time zone</td>
       <td>
-        <select name="timezone" style="width:600px;">
+        <select name="timezone">
           {% for tz, disp in timezones %}
           <option value="{{ tz }}"{% if talk.timezone == tz %} selected{% endif %}>{{disp}}</option>
           {% endfor %}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="90" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">
@@ -126,7 +126,7 @@
   <table>
     <tr>
       <td colspan="2">
-        <textarea cols="90" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
+        <textarea cols="89" rows="10" name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here">{{talk.abstract | blanknone }}</textarea>
       </td>
     </tr>
   </table>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -65,7 +65,7 @@
       </td>
     </tr>
     <tr>
-      <td>Live link</td>
+      <td>Livestream link</td>
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the seminar or talk comments how to get the link.</td>
     </tr>
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="5" style="width:770px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -26,7 +26,7 @@
     <tr>
       <td>Topics</td>
       <td>
-            <span id="topic_selector"></span>
+        <span id="topic_selector"></span>
       </td>
     </tr>
     <tr>
@@ -85,7 +85,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="80" rows="3" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="76" rows="5" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width: 700px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="5" style="width:780px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="5" style="width:770px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -83,7 +83,7 @@
       <td colspan="2">Comments</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="5" style="width:750px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="5" style="width:780px;" name="comments">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -233,7 +233,7 @@ class WebSeminar(object):
 
     def show_comments(self):
         if self.comments:
-            return "\n".join("<p>%s</p>\n" % (elt) for elt in self.comments.split("\n\n"))
+            return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(self.comments).split("\n\n"))
         else:
             return ""
 

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -12,6 +12,7 @@ from seminars.utils import (
     adapt_weektime,
     adapt_datetime,
     toggle,
+    make_links,
 )
 from lmfdb.utils import flash_error
 from lmfdb.backend.utils import DelayCommit, IdentifierWrapper

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -277,6 +277,18 @@ class WebTalk(object):
         else:  # should never happen
             return ""
 
+    def show_paper_link(self):
+        return '<a href="%s">paper</a>'%(self.paper_link) if self.paper_link else ""
+
+    def show_slides_link(self):
+        return '<a href="%s">paper</a>'%(self.slides_link) if self.slides_link else ""
+
+    def show_video_link(self):
+        return '<a href="%s">paper</a>'%(self.video_link) if self.video_link else ""
+
+    def is_past(self):
+        return self.end_time < datetime.datetime.now(pytz.utc)
+
     def is_subscribed(self):
         if current_user.is_anonymous:
             return False

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -366,8 +366,8 @@ class WebTalk(object):
 
     def show_comments(self):
         if self.comments != self.seminar.comments:
-            print self.comments
-            print self.seminar.comments
+            print(self.comments)
+            print(self.seminar.comments)
         if self.comments:
             return "\n".join("<p>%s</p>\n" % (elt) for elt in self.comments.split("\n\n"))
         else:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -58,8 +58,8 @@ class WebTalk(object):
                 if key == "id" or hasattr(self, key):
                     continue
                 elif db.seminars.col_type.get(key) == typ and getattr(seminar, key, None):
-                    # carry over from seminar
-                    setattr(self, key, getattr(seminar, key))
+                    # carry over from seminar, but not comments
+                    setattr(self, key, getattr(seminar, key) if key != "comments" else "")
                 elif typ == "text":
                     setattr(self, key, "")
                 elif typ == "text[]":

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -11,6 +11,7 @@ from seminars.utils import (
     max_distinct,
     adapt_datetime,
     toggle,
+    make_links,
 )
 from seminars.seminar import WebSeminar, can_edit_seminar
 from lmfdb.utils import flash_error
@@ -365,20 +366,14 @@ class WebTalk(object):
         return "".join("<td %s>%s</td>" % c for c in cols)
 
     def show_comments(self):
-        if self.comments != self.seminar.comments:
-            print(self.comments)
-            print(self.seminar.comments)
         if self.comments:
-            return "\n".join("<p>%s</p>\n" % (elt) for elt in self.comments.split("\n\n"))
+            return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(self.comments).split("\n\n"))
         else:
             return ""
 
-    def split_abstract(self):
-        return self.abstract.split("\n\n")
-
     def show_abstract(self):
         if self.abstract:
-            return "\n".join("<p>%s</p>\n" % (elt) for elt in self.split_abstract())
+            return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(self.abstract).split("\n\n"))
         else:
             return "<p>TBA</p>"
 

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -281,10 +281,10 @@ class WebTalk(object):
         return '<a href="%s">paper</a>'%(self.paper_link) if self.paper_link else ""
 
     def show_slides_link(self):
-        return '<a href="%s">paper</a>'%(self.slides_link) if self.slides_link else ""
+        return '<a href="%s">slides</a>'%(self.slides_link) if self.slides_link else ""
 
     def show_video_link(self):
-        return '<a href="%s">paper</a>'%(self.video_link) if self.video_link else ""
+        return '<a href="%s">video</a>'%(self.video_link) if self.video_link else ""
 
     def is_past(self):
         return self.end_time < datetime.datetime.now(pytz.utc)
@@ -365,6 +365,9 @@ class WebTalk(object):
         return "".join("<td %s>%s</td>" % c for c in cols)
 
     def show_comments(self):
+        if self.comments != self.seminar.comments:
+            print self.comments
+            print self.seminar.comments
         if self.comments:
             return "\n".join("<p>%s</p>\n" % (elt) for elt in self.comments.split("\n\n"))
         else:

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -35,5 +35,5 @@
 
 </div>
   <div align="right">
-    <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Talk's home page</a>
+    <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Talk page</a>
   </div>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -7,19 +7,30 @@
   </p>
 
   <p>
-    {{ talk.show_live_link() | safe }}
-    {% if talk.room %}
-    Lecture held in {{ talk.room }}.
-    {% endif %}
+    {% if not talk.is_past() %} {{ talk.show_live_link() | safe }} {% endif %}
+    {% if talk.room %} Lecture held in {{ talk.room }}. {% endif %}
   </p>
 
-  <h3>Abstract</h3>
-  {{ talk.show_abstract() | safe}}
+  {% if talk.paper_link or talk.slides_link or talk.video_link %}
+  <p>({% if talk.paper_link %} {{ talk.show_paper_link() | safe }} {% endif %}
+      {% if talk.slides_link %} {{ talk.show_slides_link() | safe }} {% endif %}
+      {% if talk.paper_link %} {{ talk.show_video_link() | safe }} {% endif %})
+  </p>
+  {% endif %}
 
+  {% if talk.abstract %}
+    <h3> Abstract </h3>
+    {{ talk.show_abstract() | safe }}
+  {% endif %}
 
-  {% if talk.comments %}
+  {% if talk.comments and talk.comments != talk.seminar.comments %}
   <hr>
   <p>{{talk.show_comments() | safe}}</p>
+  {% endif %}
+
+  {% if talk.seminar.comments %}
+  <hr>
+  <p>{{talk.seminar.show_comments() | safe}}</p>
   {% endif %}
 
 </div>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -39,7 +39,6 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
     <h3> Abstract </h3>
     {{ talk.show_abstract() | safe }}
   {% endif %}
-  {% if talk.paper_link %}
 
   {% if talk.comments and talk.comments != talk.seminar.comments %}
   <hr>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -19,28 +19,35 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
 {% endif %}
 
 <div class="talk-body">
-  <p>
-    {{ talk.show_speaker_and_seminar() | safe }}
-  </p>
+  <p>{{ talk.show_speaker_and_seminar() | safe }}</p>
+
+  <p>{{ talk.show_time_and_duration() | safe }}{% if talk.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.{% endif %}</p>
 
   <p>
-    {{ talk.show_time_and_duration() | safe }}{% if talk.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.{% endif %}
+    {% if not talk.is_past() %} {{ talk.show_live_link() | safe }} {% endif %}
+    {% if talk.room %} Lecture held in {{ talk.room }}. {% endif %}
   </p>
 
-  <p>
-    {{ talk.show_live_link() | safe }}
-    {% if talk.room %}
-    Lecture held in {{ talk.room }}.
-    {% endif %}
+  {% if talk.paper_link or talk.slides_link or talk.video_link %}
+  <p>({% if talk.paper_link %} {{ talk.show_paper_link() | safe }} {% endif %}
+      {% if talk.slides_link %} {{ talk.show_slides_link() | safe }} {% endif %}
+      {% if talk.paper_link %} {{ talk.show_video_link() | safe }} {% endif %})
   </p>
 
+  {% if talk.abstract %}
+    <h3> Abstract </h3>
+    {{ talk.show_abstract() | safe }}
+  {% endif %}
+  {% if talk.paper_link %}
 
-  <h3> Abstract </h3>
-  {{ talk.show_abstract() | safe }}
-
-  {% if talk.comments %}
+  {% if talk.comments and talk.comments != talk.seminar.comments %}
   <hr>
   <p>{{talk.show_comments() | safe}}</p>
+  {% endif %}
+
+  {% if talk.seminar.comments %}
+  <hr>
+  <p>{{talk.seminar.show_comments() | safe}}</p>
   {% endif %}
 
 </div>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -33,6 +33,7 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
       {% if talk.slides_link %} {{ talk.show_slides_link() | safe }} {% endif %}
       {% if talk.paper_link %} {{ talk.show_video_link() | safe }} {% endif %})
   </p>
+  {% endif %}
 
   {% if talk.abstract %}
     <h3> Abstract </h3>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -49,7 +49,6 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   <hr>
   <p>{{talk.seminar.show_comments() | safe}}</p>
   {% endif %}
-
 </div>
 
 {% endblock %}

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -25,6 +25,15 @@ def validate_url(x):
     except:
         return False
 
+def make_links(x):
+    """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
+    tokens = x.split(' ')
+    for i in range(len(tokens)):
+        if tokens[i].startswith("https://"):
+            tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][8:])
+        if tokens[i].startswith("http://"):
+            tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][7:])
+    return ' '.join(tokens)
 
 def naive_utcoffset(tz):
     if isinstance(tz, str):


### PR DESCRIPTION
This PR has a bunch of UI improvements to the edit talk/seminar and view talk pages.

Links to slides/paper/video are now shown on the View talk page and in talk knowls.

Talk and seminar comments are now both displayed, but only if they are not equal (currently the case for most talks since we have been copying the seminar comment into the talk comments)  The placeholder text for the talk comment explains that the talk comment is only for comments specific to this talk, and seminar comments are no longer copied into talk comments when new talks are created.