### PR TITLE
Knowlified create seminar/institution pages

### DIFF
--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -9,9 +9,9 @@
   For the moment any content you create will be visible only to you, but once your account has been endorsed all the seminars and talks you have registered will appear on our public browse and search pages.
 </p>
 <p>
-  Your account may endorsed by anyone with an account on our site who has already been endorsed.  You can scan this <a href="{{ url_for('user.public_users') }}">list</a> 
-  to see if you know someone who can endorse your account, or you can <a href="mailto:mathseminars@math.mit.edu">email us</a> for an endorsement.
-  If you email us, please include a link to a page at your home institution, an arXiv preprint you posted, or a published paper in which your email address appears so
+  Your accountcan be endorsed by anyone with an account on our site who has already been endorsed.
+  You may peruse this <a href="{{ url_for('user.public_users') }}">list</a>  to see if you know someone who can endorse your account, or you can <a href="mailto:mathseminars@math.mit.edu">email us</a> for an endorsement.
+  If you do email us, please include a link to a page at your home institution, an arXiv preprint you posted, or a published paper in which your email address appears so
   that we can be sure it is really you.
 </p>
 {% else %}

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -22,7 +22,7 @@
 <form action="{{ url_for('.edit_seminar') }}" method="POST">
   <input type="hidden" name="new" value="yes"/>
   <input type="hidden" name="institutions" value=""/>
-  <table id="make_semconf">
+  <table id="make_semconf" style="width:500px;">
     <tr>
       <th>{{ KNOWL("is_conference") }}</th>
       <td>
@@ -35,11 +35,11 @@
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>
-      <td><input name="shortname" placeholder="MySeminar or Riemann200" maxlength="32"/></td>
+      <td><input size="20" name="shortname" placeholder="MySeminar or Riemann200" maxlength="32"/></td>
     </tr>
     <tr>
       <th>{{ KNOWL("name") }}</th>
-      <td><input size="40" name="name" style="width:500px;" maxlength="100" placeholder="Pangaea analysis seminar"/></td>
+      <td><input size="60" name="name" style="width:500px;" maxlength="100" placeholder="Pangaea analysis seminar"/></td>
       <td class="forminfo">Capitalize only first word and proper names.</td>
     </tr>
     <tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -6,15 +6,15 @@
 {% if not user.is_creator %}
 <p>
   You are currently not endorsed.
+  You are welcome to create seminars and talkk, but they will not be visible to anyone else until your account has been endorsed, nor can you create institutions.
   If you want to add seminars to the site, you need to be endorsed by someone on the site.
-  Once you have been endorsed, you can
-  endorse others. See if you know anyone on this <a href="{{ url_for('user.public_users') }}">list</a> of
-  all seminar organizers and curators if you are seeking an
-  endorsement.
+  Once you have been endorsed, you can  endorse others.
+  See if you know anyone on this <a href="{{ url_for('user.public_users') }}">list</a> of
+  seminar organizers and curators, or you can <a href="mailto:mathseminars@math.mit.edu>email us</a> to request an endorsement.
 {% endif %}
 
 {% if user.affiliation and not institution_known(user.affiliation) %}
-<p> Your affiliation doesn't appear to be on our list of institutions.  You may want to <a href="{{ url_for('list_institutions') }}">add your institution</a> before creating a seminar, after you are endorsed.
+<p> Your affiliation doesn't appear to be on our list of institutions.  You may want to <a href="{{ url_for('list_institutions') }}">add your institution</a> before creating a seminar or conference, or you can create the seminar now and add an institution later.
 {% endif %}
 
 <h2>Create a seminar or conference</h2>
@@ -31,7 +31,7 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo"><p style="width:200px; color:#606060;">Click blue captions for instructions.</p></td>
+      <td class="forminfo"><p style="width:200px;">Click blue captions for instructions.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -22,7 +22,7 @@
 <form action="{{ url_for('.edit_seminar') }}" method="POST">
   <input type="hidden" name="new" value="yes"/>
   <input type="hidden" name="institutions" value=""/>
-  <table id="make_semconf" style="width:500px;">
+  <table id="make_semconf" style="width:600px;">
     <tr>
       <th>{{ KNOWL("is_conference") }}</th>
       <td>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -18,7 +18,6 @@
 {% endif %}
 
 <h2>Create a seminar or conference</h2>
-<small>(click blue captions for instructions)</small>
 
 <form action="{{ url_for('.edit_seminar') }}" method="POST">
   <input type="hidden" name="new" value="yes"/>
@@ -32,7 +31,7 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo" style="width:200px;"><p style="width:300px;">Click the blue captions for instructions.</p></td>
+      <td class="forminfo"><p style="width:200px;">Click the blue captions for instructions.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>
@@ -41,11 +40,12 @@
     <tr>
       <th>{{ KNOWL("name") }}</th>
       <td><input size="60" name="name" style="width:500px;" maxlength="100" placeholder="Pangaea analysis seminar"/></td>
-      <td class="forminfo">Capitalize only first word and proper names.</td>
+      <td class="forminfo">Capitalizefirst word and proper names.</td>
     </tr>
     <tr>
       <th>{{ KNOWL("institutions") }}</th>
       <td><span id="institution_selector"></span></td>
+      <td class="forminfo">you can add these latter.</td>
     <tr>
       <td><button type="submit">Create</button></td>
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -31,7 +31,7 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo"><p style="width:200px;">Click the blue captions for instructions.</p></td>
+      <td class="forminfo"><p style="width:200px;">Click blue captions for instructions.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>
@@ -40,12 +40,12 @@
     <tr>
       <th>{{ KNOWL("name") }}</th>
       <td><input size="60" name="name" style="width:500px;" maxlength="100" placeholder="Pangaea analysis seminar"/></td>
-      <td class="forminfo">Capitalizefirst word and proper names.</td>
+      <td class="forminfo">Capitalize first word and proper names.</td>
     </tr>
     <tr>
       <th>{{ KNOWL("institutions") }}</th>
       <td><span id="institution_selector"></span></td>
-      <td class="forminfo">you can add these latter.</td>
+      <td class="forminfo">You can add these latter.</td>
     <tr>
       <td><button type="submit">Create</button></td>
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -22,7 +22,7 @@
 <form action="{{ url_for('.edit_seminar') }}" method="POST">
   <input type="hidden" name="new" value="yes"/>
   <input type="hidden" name="institutions" value=""/>
-  <table id="make_semconf" style="width:600px;">
+  <table id="make_semconf">
     <tr>
       <th>{{ KNOWL("is_conference") }}</th>
       <td>
@@ -31,7 +31,7 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo">Click the blue captions for instructions.</td>
+      <td class="forminfo" style="width:200px;">Click the blue captions for instructions.</td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -31,7 +31,7 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo"><p style="width:200px;">Click blue captions for instructions.</p></td>
+      <td class="forminfo"><p style="width:200px; color:#606060;">Click blue captions for instructions.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -38,11 +38,11 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
       <td class="forminfo"><p style="width:150px;">Click blue captions for an explanation of each item.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("shortname") }}</th>
+      <th>{{ KNOWL("seminar_shortname") }}</th>
       <td><input size="20" name="shortname" placeholder="TeaAndTopology" maxlength="32"/></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("name") }}</th>
+      <th>{{ KNOWL("seminar_name") }}</th>
       <td><input size="60" name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -18,6 +18,7 @@
 {% endif %}
 
 <h2>Create a seminar or conference</h2>
+<small>(click blue captions for instructions)</small>
 
 <form action="{{ url_for('.edit_seminar') }}" method="POST">
   <input type="hidden" name="new" value="yes"/>
@@ -31,7 +32,7 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo" style="width:200px;">Click the blue captions for instructions.</td>
+      <td class="forminfo" style="width:200px;"><p style="width:300px;">Click the blue captions for instructions.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>
@@ -45,7 +46,6 @@
     <tr>
       <th>{{ KNOWL("institutions") }}</th>
       <td><span id="institution_selector"></span></td>
-      <td class="forminfo">You can create and add institutions later if you need to.</td>
     <tr>
       <td><button type="submit">Create</button></td>
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -24,36 +24,28 @@
   <input type="hidden" name="institutions" value=""/>
   <table id="make_semconf">
     <tr>
-      <th>Type</th>
+      <th>{{ KNOWL("is_conference") }}</th>
       <td>
         <select name="is_conference" style="width:100px;">
           <option value="yes">conference</option>
           <option value="no" selected>seminar</option>
         </select>
       </td>
+      <td class="forminfo">Click the blue captions for instructions.</td>
     </tr>
     <tr>
-      <th>Identifier</th>
-      <td><input name="shortname" placeholder="ShortLabel" /></td>
+      <th>{{ KNOWL("shortname") }}</th>
+      <td><input name="shortname" placeholder="MySeminar or Riemann200" maxlength="32"/></td>
     </tr>
     <tr>
-      <td class="forminfo" colspan="2">The identifier is used in the URL, so use only letters, numbers, hyphens and underscores - no spaces.</td>
+      <th>{{ KNOWL("name") }}</th>
+      <td><input size="40" name="name" style="width:500px;" maxlength="100" placeholder="Pangaea analysis seminar"/></td>
+      <td class="forminfo">Capitalize only first word and proper names.</td>
     </tr>
     <tr>
-      <th>Full name</th>
-      <td><input size="40" name="name" style="width:500px;" placeholder="Pangaea analysis seminar"/></td>
-    </tr>
-    <tr>
-      <td class="forminfo" colspan="2">Generally, capitalize only the first word and proper names.</td>
-    </tr>
-    <tr>
-      <th>Institutions</th>
-      <td>
-        <span id="institution_selector"></span>
-      </td>
-    <tr>
-      <td class="forminfo" colspan="2">If a relevant institution isn't in the dropdown list, <a href="{{ url_for('list_institutions') }}">add it</a> before or after creating the seminar, after you are endorsed.</td>
-    </tr>
+      <th>{{ KNOWL("institutions") }}</th>
+      <td><span id="institution_selector"></span></td>
+      <td class="forminfo">You can create and add institutions later if you need to.</td>
     <tr>
       <td><button type="submit">Create</button></td>
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -5,16 +5,19 @@
 <div class="text_content">
 {% if not user.is_creator %}
 <p>
-  You are currently not endorsed.
-  You are welcome to create seminars and talkk, but they will not be visible to anyone else until your account has been endorsed, nor can you create institutions.
-  If you want to add seminars to the site, you need to be endorsed by someone on the site.
-  Once you have been endorsed, you can  endorse others.
-  See if you know anyone on this <a href="{{ url_for('user.public_users') }}">list</a> of
-  seminar organizers and curators, or you can <a href="mailto:mathseminars@math.mit.edu>email us</a> to request an endorsement.
-{% endif %}
-
+  Welcome!  It looks like your account has not yet been endorsed, but please feel free to start creating seminars (but not insitutions).
+  Any content you create will be visible only to you for the moment, but once your account has been endorsed, all the seminars and talks you have registered will appear on our public browse and search pages.
+</p>
+<p>
+  You can have your account endorsed by anyone who has already been endorsed; you may check this <a href="{{ url_for('user.public_users') }}">list</a> 
+  to see if you know someone who can endorse your account, or you can <a href="mailto:mathseminars@math.mit.edu">email us</a> to ask for an endorsement.
+  If you choose to email us, please include a link to a page at your home institution, an arXiv preprint you posted, or a published paper in which your email appears.
+</p>
+{% else %}
 {% if user.affiliation and not institution_known(user.affiliation) %}
-<p> Your affiliation doesn't appear to be on our list of institutions.  You may want to <a href="{{ url_for('list_institutions') }}">add your institution</a> before creating a seminar or conference, or you can create the seminar now and add an institution later.
+<p> Your affiliation does not appear to be on our list of institutions.
+You may want to <a href="{{ url_for('list_institutions') }}">add your institution</a> before creating a seminar or conference;  alternativley, you can create a seminar now and add an institution to it later.
+{% endif %}
 {% endif %}
 
 <h2>Create a seminar or conference</h2>
@@ -31,16 +34,16 @@
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo"><p style="width:200px;">Click blue captions for instructions.</p></td>
+      <td class="forminfo"><p style="width:150px;">Click blue captions for instructions.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>
-      <td><input size="20" name="shortname" placeholder="MySeminar or Riemann200" maxlength="32"/></td>
+      <td><input size="20" name="shortname" placeholder="TeaAndTopology" maxlength="32"/></td>
     </tr>
     <tr>
       <th>{{ KNOWL("name") }}</th>
-      <td><input size="60" name="name" style="width:500px;" maxlength="100" placeholder="Pangaea analysis seminar"/></td>
-      <td class="forminfo">Capitalize first word and proper names.</td>
+      <td><input size="60" name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
+      <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>
     <tr>
       <th>{{ KNOWL("institutions") }}</th>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -5,18 +5,19 @@
 <div class="text_content">
 {% if not user.is_creator %}
 <p>
-  Welcome!  It looks like your account has not yet been endorsed, but please feel free to start creating seminars (but not insitutions).
-  Any content you create will be visible only to you for the moment, but once your account has been endorsed, all the seminars and talks you have registered will appear on our public browse and search pages.
+  Welcome!  It looks like your account yet to be endorsed, but please feel free to start creating seminars (but not insitutions).
+  For the moment any content you create will be visible only to you, but once your account has been endorsed all the seminars and talks you have registered will appear on our public browse and search pages.
 </p>
 <p>
-  You can have your account endorsed by anyone who has already been endorsed; you may check this <a href="{{ url_for('user.public_users') }}">list</a> 
-  to see if you know someone who can endorse your account, or you can <a href="mailto:mathseminars@math.mit.edu">email us</a> to ask for an endorsement.
-  If you choose to email us, please include a link to a page at your home institution, an arXiv preprint you posted, or a published paper in which your email appears.
+  Your account may endorsed by anyone with an account on our site who has already been endorsed.  You can scan this <a href="{{ url_for('user.public_users') }}">list</a> 
+  to see if you know someone who can endorse your account, or you can <a href="mailto:mathseminars@math.mit.edu">email us</a> for an endorsement.
+  If you email us, please include a link to a page at your home institution, an arXiv preprint you posted, or a published paper in which your email address appears so
+  that we can be sure it is really you.
 </p>
 {% else %}
 {% if user.affiliation and not institution_known(user.affiliation) %}
 <p> Your affiliation does not appear to be on our list of institutions.
-You may want to <a href="{{ url_for('list_institutions') }}">add your institution</a> before creating a seminar or conference;  alternativley, you can create a seminar now and add an institution to it later.
+You may want to <a href="{{ url_for('list_institutions') }}">add your institution</a> before creating a seminar or conference.  Alternativley, you can create a seminar now and add an institution to it later.
 {% endif %}
 {% endif %}
 
@@ -34,7 +35,7 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo"><p style="width:150px;">Click blue captions for instructions.</p></td>
+      <td class="forminfo"><p style="width:150px;">Click blue captions for an explanation of each item.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("shortname") }}</th>
@@ -48,7 +49,7 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
     <tr>
       <th>{{ KNOWL("institutions") }}</th>
       <td><span id="institution_selector"></span></td>
-      <td class="forminfo">You can add these latter.</td>
+      <td class="forminfo">You can also add these latter.</td>
     <tr>
       <td><button type="submit">Create</button></td>
     </tr>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -27,7 +27,7 @@
         <input type="hidden" name="is_conference" value="{% if seminar.is_conference %}yes{% else %}no{% endif %}"/>
       <table>
         <tr>
-          <td style="width:150px;">Identifier</td>
+          <td style="width:150px;">{{ KNOWL("Identifier") }}</td>
           <td>{{ seminar.shortname }}</td>
         </tr>
         <tr>

--- a/seminars/institution.py
+++ b/seminars/institution.py
@@ -109,9 +109,9 @@ class WebInstitution(object):
 ### FIXME ###
 # Should always return a WebInstitution object but currently may returna dictionary or WebObject
 def can_edit_institution(shortname, new):
-    if not allowed_shortname(shortname):
+    if not allowed_shortname(shortname) or len(shortname) < 2 or len(shortname) > 32:
         flash_error(
-            "The identifier must be nonempty and can include only letters, numbers, hyphens and underscores."
+            "The identifier must be 2 to 32 characters in length and can include only letters, numbers, hyphens and underscores."
         )
         return redirect(url_for("list_institutions"), 302), None
     institution = db.institutions.lookup(shortname)

--- a/seminars/knowls.py
+++ b/seminars/knowls.py
@@ -24,9 +24,7 @@ def static_knowl(name, title=None):
             return title
     if title is None:
         title = knowl.get("title", "")
-    print(knowl)
-    print(knowl.keys())
-    knowl.contents=Markup(knowl.get("contents"))
+    knowl["contents"]=Markup(knowl.get("contents",""))
     return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
         title=title, content=Markup.escape(render_template("static-knowl.html", knowl=knowl))
     )

--- a/seminars/knowls.py
+++ b/seminars/knowls.py
@@ -24,6 +24,8 @@ def static_knowl(name, title=None):
             return title
     if title is None:
         title = knowl.get("title", "")
+    print(knowl)
+    print(knowl.keys())
     knowl.contents=Markup(knowl.get("contents"))
     return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
         title=title, content=Markup.escape(render_template("static-knowl.html", knowl=knowl))

--- a/seminars/knowls.py
+++ b/seminars/knowls.py
@@ -25,5 +25,5 @@ def static_knowl(name, title=None):
     if title is None:
         title = knowl.get("title", "")
     return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
-        title=title, content=Markup.escape(render_template("static-knowl.html", knowl=knowl))
+        title=title, content=Markup(render_template("static-knowl.html", knowl=knowl))
     )

--- a/seminars/knowls.py
+++ b/seminars/knowls.py
@@ -24,7 +24,7 @@ def static_knowl(name, title=None):
             return title
     if title is None:
         title = knowl.get("title", "")
-    knowl.contents=Markup(knowl.contents)
+    knowl.contents=Markup(knowl.get("contents"))
     return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
         title=title, content=Markup.escape(render_template("static-knowl.html", knowl=knowl))
     )

--- a/seminars/knowls.py
+++ b/seminars/knowls.py
@@ -24,6 +24,7 @@ def static_knowl(name, title=None):
             return title
     if title is None:
         title = knowl.get("title", "")
+    knowl.contents=Markup(knowl.contents)
     return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
-        title=title, content=Markup(render_template("static-knowl.html", knowl=knowl))
+        title=title, content=Markup.escape(render_template("static-knowl.html", knowl=knowl))
     )

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -21,7 +21,7 @@ institutions:
     If you wish to add an institution that is not currenlty listed you can create it by clicking on the Institutions tab.  If your account has not
     yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
     Once you account has been endorsed you can create the insitution and add it to your seminar.
-    <br>
+    <br><br>
     You can get your account endorsed by anyone with an endorsed account (<a href="https://mathseminars.org/user/public">listed here</a>), or you can
     <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
     insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -22,7 +22,7 @@ institutions:
     yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
     Once you account has been endorsed you can create the insitution and add it to your seminar.
 
-    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathsemianrs.org/users/public">listed here</a>), or you can
+    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathseminars.org/users/public">listed here</a>), or you can
     <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
     insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).
 organizer_name:

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -1,32 +1,24 @@
 is_conference:
   title: Type
   contents: |
-    Seminars are best used for series of talks that recur at more or less regular intervals (every Tuesday and Thursday, or every other Wednesday for example).
+    Seminars are best used for series of talks that recur at regular intervals (every Tuesday and Thursday, or every other Wednesday, for example).
     Conferences are events with a fixed start and end date (usually a more or less consecutive sequence of days with some number of talks per day).
     For the most part seminars and conferences are treated identically on our site, the main difference is in how the grid for the talk schedule is layed out.
 shortname:
   title: Identifier
   contents: |
-    The identifier of the seminar (or conference) is a string of up to 32 characters that will be included in all URL links to the seminar and talks that take place in it.
-    It must consist of letters (case sensitive), numbers, hypens and undersores, with no spaces.
-    The identifier is permanent and cannot be changed; only identifiers of permanently deleted seminars can be reused.
+    Each seminar (or conference) must be given a unique indentifier consisting of up to 32 letters, numbers, hyphens, or underscores (no spaces) that
+    will be included in all URL links to the seminar and its associated talks.  This identifier is permanent and cannot be changed.
 name:
   title: Full name
   contents: |
-    The full name of the seminar (or conference).  This will appear on brwose and search pages and can be changed at any time.
+    The full name of the seminar (or conference) that will appear on our brwose and search pages; this be changed at any time.
     Like wikipedia, mathseminars.org uses <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> for seminar names and talk titles.
     This means that only the first word and proper nouns should be capitalized.
 institutions:
   title: Institutions
   contents: |
-    List of insitutions hosting or associated with the seminar (or conference).  These can be changed at any time and need not be specified now (or ever).
-    If you wish to add an institution that is not currenlty listed you can create it by clicking on the Institutions tab.  If your account has not
-    yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
-    Once you account has been endorsed you can create the insitution and add it to your seminar.
-    <br><br>
-    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathseminars.org/user/public">listed here</a>), or you can
-    <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
-    insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).
+    You may associate one or more institutions to a seminar (or conference).  The list of institutions may be empty and can be changed at any time.
 organizer_name:
   title: Name
   contents: |

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -1,16 +1,26 @@
+institution_shortname:
+  title: Identifier
+  contents: |
+    Each institution must be given a unique indentifier consisting of 2 to 32 letters, numbers, hyphens, or underscores.
+    You may choose any identifier that is not already in use; when you press create you will be alerted if the identifier you entered is already in use.
+    This identifier is permanent and cannot be changed.
+institution_name:
+  title: Name
+  contents: |
+    The name of your institution that will be displayed when associating institutions to seminars and conferences.  This can be changed.
 is_conference:
   title: Type
   contents: |
     Seminars are best used for series of talks that recur at regular intervals (every Tuesday and Thursday, or every other Wednesday, for example).
     Conferences are events with a fixed start and end date (usually a more or less consecutive sequence of days with some number of talks per day).
     For the most part seminars and conferences are treated identically on our site, the main difference is in how the grid for the talk schedule is layed out.
-shortname:
+seminar_shortname:
   title: Identifier
   contents: |
     Each seminar (or conference) has a unique indentifier consisting of 3 to 32 letters, numbers, hyphens, or underscores (no spaces) that
     will be included in all URL links to the seminar and its associated talks.  You may choose any identifier that is not already in use;
     when you press create you will be told if the identifier you entered is already in use.  This identifier is permanent and cannot be changed.
-name:
+seminar_name:
   title: Full name
   contents: |
     The full name of the seminar (or conference) that will appear on our brwose and search pages; this can be changed at any time.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -1,3 +1,30 @@
+is_conference:
+  title: Type
+  contents: |
+    Seminars are best used for series of talks that recur at more or less regular intervals (every Tuesday and Thursday, or every other Wednesday for example).
+    Conferences are events with a fixed start and end date (usually a more or less consecutive sequence of days with some number of talks per day).
+    For the most part seminars and conferences are treated identically on our site, the main difference is in how the grid for the talk schedule is layed out.
+shortname:
+  title: Identifier
+  contents: |
+    The identifier of the seminar (or conference) is a string of up to 32 characters that will be included in all URL links to the seminar and talks that take place in it.
+    It must consist of letters (case sensitive), numbers, hypens and undersores, with no spaces.
+    The identifier is permanent and cannot be changed; only identifiers of permanently deleted seminars can be reused.
+seminar_name:
+  title: Full name
+  contents: |
+    The full name of the seminar or conference.  This will appear on brwose and search pages and can be changed at any time.
+institutions:
+  title: Institutions
+  contents: |
+    List of insitutions hosting or associated with the seminar (or conference).  These can be changed at any time and need not be specified now (or ever).
+    If you wish to add an institution that is not currenlty listed you can create it by clicking on the Institutions tab.  If your account has not
+    yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
+    Once you account has been endorsed you can create the insitution and add it to your seminar.
+
+    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathsemianrs.org/users/public">listed here), or you can
+    <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
+    insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).
 organizer_name:
   title: Name
   contents: |

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -7,13 +7,14 @@ is_conference:
 shortname:
   title: Identifier
   contents: |
-    Each seminar (or conference) must be given a unique indentifier consisting of up to 32 letters, numbers, hyphens, or underscores (no spaces) that
-    will be included in all URL links to the seminar and its associated talks.  This identifier is permanent and cannot be changed.
+    Each seminar (or conference) has a unique indentifier consisting of 3 to 32 letters, numbers, hyphens, or underscores (no spaces) that
+    will be included in all URL links to the seminar and its associated talks.  You may choose any identifier that is not already in use;
+    when you press create you will be told if the identifier you entered is already in use.  This identifier is permanent and cannot be changed.
 name:
   title: Full name
   contents: |
-    The full name of the seminar (or conference) that will appear on our brwose and search pages; this be changed at any time.
-    Like wikipedia, mathseminars.org uses <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> for seminar names and talk titles.
+    The full name of the seminar (or conference) that will appear on our brwose and search pages; this can be changed at any time.
+    Like Wikipedia, mathseminars.org uses <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> for seminar names and talk titles.
     This means that only the first word and proper nouns should be capitalized.
 institutions:
   title: Institutions

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -13,7 +13,9 @@ shortname:
 name:
   title: Full name
   contents: |
-    The full name of the seminar or conference.  This will appear on brwose and search pages and can be changed at any time.
+    The full name of the seminar (or conference).  This will appear on brwose and search pages and can be changed at any time.
+    Like wikipedia, mathseminars.org uses <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> for seminar names and talk titles.
+    This means that only the first word and proper nouns should be capitalized.
 institutions:
   title: Institutions
   contents: |

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -10,7 +10,7 @@ shortname:
     The identifier of the seminar (or conference) is a string of up to 32 characters that will be included in all URL links to the seminar and talks that take place in it.
     It must consist of letters (case sensitive), numbers, hypens and undersores, with no spaces.
     The identifier is permanent and cannot be changed; only identifiers of permanently deleted seminars can be reused.
-seminar_name:
+name:
   title: Full name
   contents: |
     The full name of the seminar or conference.  This will appear on brwose and search pages and can be changed at any time.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -22,7 +22,7 @@ institutions:
     yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
     Once you account has been endorsed you can create the insitution and add it to your seminar.
 
-    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathseminars.org/users/public">listed here</a>), or you can
+    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathseminars.org/user/public">listed here</a>), or you can
     <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
     insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).
 organizer_name:

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -21,7 +21,7 @@ institutions:
     If you wish to add an institution that is not currenlty listed you can create it by clicking on the Institutions tab.  If your account has not
     yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
     Once you account has been endorsed you can create the insitution and add it to your seminar.
-
+    <br>
     You can get your account endorsed by anyone with an endorsed account (<a href="https://mathseminars.org/user/public">listed here</a>), or you can
     <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
     insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -22,7 +22,7 @@ institutions:
     yet been endorsed you will not be able to create new institutions, but feel free to create your seminar now if you wish.
     Once you account has been endorsed you can create the insitution and add it to your seminar.
 
-    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathsemianrs.org/users/public">listed here), or you can
+    You can get your account endorsed by anyone with an endorsed account (<a href="https://mathsemianrs.org/users/public">listed here</a>), or you can
     <a href="mailto:mathseminars@math.mit.edu">email us</a> to request an endorsement (to help us verify your identity, please include a link to your
     insitutional profile page, an arXiv preprint, or published mathematics paper that includes your email contact information).
 organizer_name:

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -21,7 +21,7 @@ seminar_shortname:
     will be included in all URL links to the seminar and its associated talks.  You may choose any identifier that is not already in use;
     when you press create you will be told if the identifier you entered is already in use.  This identifier is permanent and cannot be changed.
 seminar_name:
-  title: Full name
+  title: Name
   contents: |
     The full name of the seminar (or conference) that will appear on our brwose and search pages; this can be changed at any time.
     Like Wikipedia, mathseminars.org uses <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> for seminar names and talk titles.

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -490,9 +490,9 @@ def can_edit_seminar(shortname, new):
     - ``seminar`` -- a WebSeminar object, as returned by ``seminars_lookup(shortname)``,
                      or ``None`` (if error or seminar does not exist)
     """
-    if not allowed_shortname(shortname):
+    if not allowed_shortname(shortname) or len(shortname) < 3 or len(shortname) > 32:
         flash_error(
-            "The identifier must be nonempty and can include only letters, numbers, hyphens and underscores."
+            "The identifier must be 3 to 32 characters in length and can include only letters, numbers, hyphens and underscores."
         )
         return redirect(url_for(".index"), 302), None
     seminar = seminars_lookup(shortname, include_deleted=True)

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -12,15 +12,12 @@
   <input type="hidden" name="new" value="yes"/>
   <table id="make_inst">
     <tr>
-      <th>Identifier:</th>
-      <td><input name="shortname" placeholder="ShortLabel"/></td>
+      <td>{{ KNOWL("institution_shortname") }}</td>
+      <td><input name="shortname" placeholder="UPan" maxlength="32"/></td>
     </tr>
     <tr>
-      <td class="forminfo" colspan="2">The identifier is used in the URL, so use only letters, numbers, hyphens and underscores - no spaces.</td>
-    </tr>
-    <tr>
-      <th>Name</th>
-      <td><input size="40" name="name" style="width:500px;" placeholder="University of Pangaea" /></td>
+      <td>{{ KNOWL("institution_name") }}</td>
+      <td><input size="40" name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
     </tr>
     <tr>
       <td><button type="submit">Create</button></td>

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -12,11 +12,12 @@
   <input type="hidden" name="new" value="yes"/>
   <table id="make_inst">
     <tr>
-      <td>{{ KNOWL("institution_shortname") }}</td>
+      <th>{{ KNOWL("institution_shortname") }}</th>
       <td><input name="shortname" placeholder="UPan" maxlength="32"/></td>
+      <td class="forminfo"><p style="width:150px;">Click blue captions for an explanation of each item.</p></td>
     </tr>
     <tr>
-      <td>{{ KNOWL("institution_name") }}</td>
+      <th>{{ KNOWL("institution_name") }}</th>
       <td><input size="40" name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
     </tr>
     <tr>

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {RGC(80,80,80)};
+   color: {RGC(70,70,70)};
    vertical-align: top;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {{color.grey}};
+   color: {RGC(80,80,80)};
    vertical-align: top;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -337,7 +337,7 @@ div.topic_cmd {
 #make_semconf td.forminfo, #make_inst td.forminfo {
     padding-bottom: 15px;
 }
-#make_semconf th #mak_inst th {
+#make_semconf th #make_inst th {
     text-align: left;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {rgb(256,80,80)};
+   color: {{color.blue}};
    vertical-align: top;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -337,7 +337,7 @@ div.topic_cmd {
 #make_semconf td.forminfo, #make_inst td.forminfo {
     padding-bottom: 15px;
 }
-#make_semconf th #make_inst th {
+#make_semconf th, #make_inst th {
     text-align: left;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {{color.grey}};
+   color: #606080;
    vertical-align: top;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -764,6 +764,12 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
    color: {{color.red}};
 }
 
+.forminfo {
+   font-size: 80%;
+   font-style: italic;
+   color: {{color.grey}};
+   vertical-align: top;
+}
 
 input, textarea {
   border: 2px solid {{color.input_border}};

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -337,7 +337,7 @@ div.topic_cmd {
 #make_semconf td.forminfo, #make_inst td.forminfo {
     padding-bottom: 15px;
 }
-#make_semconf th {
+#make_semconf th #mak_inst th {
     text-align: left;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {{color.blue}};
+   color: {{color.grey}};
    vertical-align: top;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {rgb(60,60,60)};
+   color: {rgb(256,80,80)};
    vertical-align: top;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -764,12 +764,6 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
    color: {{color.red}};
 }
 
-.forminfo {
-   font-size: 80%;
-   font-style: italic;
-   color: #606080;
-   vertical-align: top;
-}
 
 input, textarea {
   border: 2px solid {{color.input_border}};

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -767,7 +767,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 .forminfo {
    font-size: 80%;
    font-style: italic;
-   color: {{color.grey}};
+   color: {rgb(60,60,60)};
    vertical-align: top;
 }
 

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -35,6 +35,6 @@
 
 </div>
 <div align="right">
-  {% if talk.user_can_edit() %}<a href="{{url_for("create.edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a>{% endif %}
+  {% if talk.user_can_edit() %}<a href="{{url_for("create.edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a><br>{% endif %}
   <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">View talk</a>
 </div>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -34,6 +34,11 @@
   {% endif %}
 
 </div>
-  <div align="right">
-    <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Talk page</a>
-  </div>
+{% if talk.user_can_edit() %}
+<div align="right">
+  <a href="{{url_for("edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a>
+</div>
+{% endif %}
+<div align="right">
+  <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">View talk</a>
+</div>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -36,7 +36,7 @@
 </div>
 {% if talk.user_can_edit() %}
 <div align="right">
-  <a href="{{url_for("edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a>
+  <a href="{{url_for("create.edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a>
 </div>
 {% endif %}
 <div align="right">

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -35,6 +35,6 @@
 
 </div>
 <div align="right">
-  {% if talk.user_can_edit() %}<a href="{{ talk.details_link() | safe }}">Edit talk</a><br>{% endif %}
-  <a href="{{ url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr) }}">View talk</a>
+  {% if talk.user_can_edit() %}<a href="{{url_for("create.edit_talk", seminar_id=talk.seminar_id, seminar_ctr=talk.seminar_ctr)}}">Edit talk</a><br>{% endif %}
+  <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">View talk</a>
 </div>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -35,6 +35,6 @@
 
 </div>
 <div align="right">
-  {% if talk.user_can_edit() %}<a href="{{url_for("create.edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a><br>{% endif %}
-  <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">View talk</a>
+  {% if talk.user_can_edit() %}<a href="{{ talk.details_link() | safe }}">Edit talk</a><br>{% endif %}
+  <a href="{{ url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr) }}">View talk</a>
 </div>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -34,11 +34,7 @@
   {% endif %}
 
 </div>
-{% if talk.user_can_edit() %}
 <div align="right">
-  <a href="{{url_for("create.edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a>
-</div>
-{% endif %}
-<div align="right">
+  {% if talk.user_can_edit() %}<a href="{{url_for("create.edit_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">Edit talk</a>{% endif %}
   <a href="{{url_for("show_talk", semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">View talk</a>
 </div>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -169,15 +169,15 @@
   <form action="{{ url_for('.change_password') }}" method="POST" name="changepassword">
    <table>
     <tr>
-     <td style="width:150px;">Old Password</td>
-     <td><input name="oldpwd" type="password" /></td>
+     <td>Old Password</td>
+     <td><input name="oldpwd" type="password" style="width:250px;"/></td>
      <tr><td colspan="2" class="forminfo" />Don't use a password that you use elsewhere!</tr>
      <tr><td>New Password</td>
-         <td><input id="pw1" name="password1" type="password" /></td>
+         <td><input id="pw1" name="password1" type="password" style="width:250px;"/></td>
          <td class="forminfo" id="pw1status" style="color: {{color.red}};"></td></tr>
      </tr>
      <tr><td>New Password (repeat)</td>
-         <td><input id="pw2" name="password2" type="password" /></td>
+         <td><input id="pw2" name="password2" type="password" style="width:250px;"/></td>
          <td class="forminfo" id="pw2status" style="color: {{color.red}};"></td></tr>
     <tr>
      <tr><td colspan="2" class="spacing" /></tr>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -92,7 +92,7 @@
     <form action="{{ url_for('.get_endorsing_link') }}" method="post" name="endorse">
     <table>
       <tr>
-        <td style="width:50px;">
+        <td style="width:70px;">
           Email
         </td>
         <td>
@@ -140,7 +140,7 @@
     <tr>
       <td>Timezone</td>
       <td>
-        <select name="timezone" style="width:350px;">
+        <select name="timezone" style="width:356px;">
         {% for tz, pretty_tz in [('', 'Browser time zone')] + timezones %}
             <option value="{{tz}}"
                     {% if tz == user.raw_timezone %}

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -92,7 +92,7 @@
     <form action="{{ url_for('.get_endorsing_link') }}" method="post" name="endorse">
     <table>
       <tr>
-        <td style="width:70px;">
+        <td style="width:74px;">
           Email
         </td>
         <td>
@@ -169,7 +169,7 @@
   <form action="{{ url_for('.change_password') }}" method="POST" name="changepassword">
    <table>
     <tr>
-     <td>Old Password</td>
+     <td style="width:150px;">Old Password</td>
      <td><input name="oldpwd" type="password" /></td>
      <tr><td colspan="2" class="forminfo" />Don't use a password that you use elsewhere!</tr>
      <tr><td>New Password</td>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -92,8 +92,8 @@
     <form action="{{ url_for('.get_endorsing_link') }}" method="post" name="endorse">
     <table>
       <tr>
-        <td>
-          Email:
+        <td style="width:100px;">
+          Email
         </td>
         <td>
           <input name="email" size="30" tabindex="1" />
@@ -110,11 +110,11 @@
   <form action="{{ url_for('.set_info') }}" method="post" name="userinfo">
     <table>
       <tr>
-        <td>Created:</td>
+        <td>Created</td>
         <td>{{ user.created|fmtdatetime }}</td>
       </tr>
       <tr>
-        <td>Email:</td>
+        <td>Email</td>
         <td><input name="email" value="{{user.email}}" size="30" tabindex="1" /></td>
         {% if not user.email_confirmed %}
         <td>
@@ -123,24 +123,24 @@
         {%endif%}
       </tr>
       <tr>
-        <td>Name:</td>
+        <td>Name</td>
         <td><input name="name" value="{{user.name}}" size="30" tabindex="1" /></td>
         <td/>
       </tr>
       <tr>
-        <td>Affiliation:</td>
+        <td>Affiliation</td>
         <td><input name="affiliation" value="{{user.affiliation}}" size="30" tabindex="1" /></td>
         <td/>
       </tr>
       <tr>
-        <td>Homepage:</td>
+        <td>Homepage</td>
         <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>
         <td id="urltest" /></td>
       </tr>
     <tr>
-      <td>Timezone:</td>
+      <td>Timezone</td>
       <td>
-        <select name="timezone">
+        <select name="timezone" style="width:200px;">
         {% for tz, pretty_tz in [('', 'Browser time zone')] + timezones %}
             <option value="{{tz}}"
                     {% if tz == user.raw_timezone %}
@@ -169,14 +169,14 @@
   <form action="{{ url_for('.change_password') }}" method="POST" name="changepassword">
    <table>
     <tr>
-     <td>Old Password:</td>
+     <td>Old Password</td>
      <td><input name="oldpwd" type="password" /></td>
      <tr><td colspan="2" class="forminfo" />Don't use a password that you use elsewhere!</tr>
-     <tr><td>New Password:</td>
+     <tr><td>New Password</td>
          <td><input id="pw1" name="password1" type="password" /></td>
          <td class="forminfo" id="pw1status" style="color: {{color.red}};"></td></tr>
      </tr>
-     <tr><td>New Password (repeat):</td>
+     <tr><td>New Password (repeat)</td>
          <td><input id="pw2" name="password2" type="password" /></td>
          <td class="forminfo" id="pw2status" style="color: {{color.red}};"></td></tr>
     <tr>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -92,7 +92,7 @@
     <form action="{{ url_for('.get_endorsing_link') }}" method="post" name="endorse">
     <table>
       <tr>
-        <td style="width:100px;">
+        <td style="width:50px;">
           Email
         </td>
         <td>
@@ -140,7 +140,7 @@
     <tr>
       <td>Timezone</td>
       <td>
-        <select name="timezone" style="width:200px;">
+        <select name="timezone" style="width:350px;">
         {% for tz, pretty_tz in [('', 'Browser time zone')] + timezones %}
             <option value="{{tz}}"
                     {% if tz == user.raw_timezone %}

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -92,7 +92,7 @@
     <form action="{{ url_for('.get_endorsing_link') }}" method="post" name="endorse">
     <table>
       <tr>
-        <td style="width:74px;">
+        <td style="width:75px;">
           Email
         </td>
         <td>
@@ -170,14 +170,14 @@
    <table>
     <tr>
      <td>Old Password</td>
-     <td><input name="oldpwd" type="password" style="width:250px;"/></td>
+     <td><input name="oldpwd" type="password" style="width:260px;"/></td>
      <tr><td colspan="2" class="forminfo" />Don't use a password that you use elsewhere!</tr>
      <tr><td>New Password</td>
-         <td><input id="pw1" name="password1" type="password" style="width:250px;"/></td>
+         <td><input id="pw1" name="password1" type="password" style="width:260px;"/></td>
          <td class="forminfo" id="pw1status" style="color: {{color.red}};"></td></tr>
      </tr>
      <tr><td>New Password (repeat)</td>
-         <td><input id="pw2" name="password2" type="password" style="width:250px;"/></td>
+         <td><input id="pw2" name="password2" type="password" style="width:260px;"/></td>
          <td class="forminfo" id="pw2status" style="color: {{color.red}};"></td></tr>
     <tr>
      <tr><td colspan="2" class="spacing" /></tr>


### PR DESCRIPTION
Added knowls to the create seminar and institution pages and tweaked layout and css.
I tried to clarify what an unendorsed user can and cannot do, and what they need to do in order to get endorsed on the create seminar page (which is the entry point for content creation for new users).

This PR also imposes length restrictions on short names that are currently satisfied: 3-32 characters for seminar id's and 2-32 characters for institution ids.  Seminar names are limited to 100 characters and institution names are limited to 64 characters (without imposing limits there is nothing stopping someone from cutting and pasting the entire text of War and Peace into a seminar shortname or name and bad things happen when you do this).

I also added an edit link (for authorized users) to talk knowls, which is very handy. for organizers (it means one less click from viewing a seminar to editing a talk).

Pushing to master to make it easier to review.