### PR TITLE
Red asterisks on create pages

### DIFF
--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -35,7 +35,7 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_name") }}<span style="color:red>*</span></th>
+      <th>{{ KNOWL("seminar_name") }}<span style="color:red">*</span></th>
       <td><input name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -25,22 +25,22 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
   <input type="hidden" name="institutions" value=""/>
   <table id="make_semconf">
     <tr>
-      <th>{{ KNOWL("is_conference") }}</th>
+      <th>{{ KNOWL("is_conference") }}<span style="color:red; font-weight:normal">*</span></th>
       <td>
         <select name="is_conference" style="width:100px;">
           <option value="yes">conference</option>
           <option value="no" selected>seminar</option>
         </select>
       </td>
-      <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
+      <td class="forminfo"><p style="width:230px;">Click blue captions for more details. Asterisks denote required items.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_name") }} <span style="color:red; font-weight:normal">*</span></th>
+      <th>{{ KNOWL("seminar_name") }}<span style="color:red; font-weight:normal">*</span></th>
       <td><input name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_shortname") }} <span style="color:red; font-weight:normal">*</span></th>
+      <th>{{ KNOWL("seminar_shortname") }}<span style="color:red; font-weight:normal">*</span></th>
       <td><input name="shortname" style="width:500px;" placeholder="TeaAndTopology" maxlength="32"/></td>
       <td class="forminfo">Use 3-32 characters, no spaces.
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -35,12 +35,12 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_name") }}<span style="color:red">*</span></th>
+      <th>{{ KNOWL("seminar_name") }} <span style="color:red; font-weight:normal">*</span></th>
       <td><input name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_shortname") }} </th>
+      <th>{{ KNOWL("seminar_shortname") }} <span style="color:red; font-weight:normal">*</span></th>
       <td><input name="shortname" style="width:500px;" placeholder="TeaAndTopology" maxlength="32"/></td>
       <td class="forminfo">Use 3-32 characters, no spaces.
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -35,12 +35,12 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_name") }}</th>
+      <th>{{ KNOWL("seminar_name") <span style="color:red>*</span>}}</th>
       <td><input name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_shortname") }}</th>
+      <th>{{ KNOWL("seminar_shortname") }} </th>
       <td><input name="shortname" style="width:500px;" placeholder="TeaAndTopology" maxlength="32"/></td>
       <td class="forminfo">Use 3-32 characters, no spaces.
     </tr>

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -35,7 +35,7 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("seminar_name") <span style="color:red>*</span>}}</th>
+      <th>{{ KNOWL("seminar_name") }}<span style="color:red>*</span></th>
       <td><input name="name" style="width:500px;" maxlength="100" placeholder="Terra firma topology colloquium"/></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -12,12 +12,12 @@
   <input type="hidden" name="new" value="yes"/>
   <table id="make_inst">
     <tr>
-      <th>{{ KNOWL("institution_name") }} <span style="color:red; font-weight:normal">*</span></th>
+      <th>{{ KNOWL("institution_name") }}<span style="color:red; font-weight:normal">*</span></th>
       <td><input name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("institution_shortname") }} <span style="color:red; font-weight:normal">*</span></th>
+      <th>{{ KNOWL("institution_shortname") }}<span style="color:red; font-weight:normal">*</span></th>
       <td><input name="shortname" style="width:500px;" placeholder="UPan" maxlength="32"/></td>
       <td class="forminfo">Use 2-32 characters, no spaces.
     </tr>

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -12,9 +12,10 @@
   <input type="hidden" name="new" value="yes"/>
   <table id="make_inst">
     <tr>
-      <th>{{ KNOWL("institution_name") }}<span style="color:red; font-weight:normal">*</span></th>
+      <td>{{ KNOWL("institution_name") }}<span style="color:red; font-weight:normal">*</span></td>
       <td><input name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
+      <td class="forminfo"><p style="width:230px;">Click blue captions for more details. Asterisks denote required items.</p></td>
     </tr>
     <tr>
       <th>{{ KNOWL("institution_shortname") }}<span style="color:red; font-weight:normal">*</span></th>

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -12,9 +12,8 @@
   <input type="hidden" name="new" value="yes"/>
   <table id="make_inst">
     <tr>
-      <td>{{ KNOWL("institution_name") }}<span style="color:red; font-weight:normal">*</span></td>
+      <th>{{ KNOWL("institution_name") }}<span style="color:red; font-weight:normal">*</span></td>
       <td><input name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
-      <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details. Asterisks denote required items.</p></td>
     </tr>
     <tr>

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -12,12 +12,12 @@
   <input type="hidden" name="new" value="yes"/>
   <table id="make_inst">
     <tr>
-      <th>{{ KNOWL("institution_name") }}</th>
+      <th>{{ KNOWL("institution_name") }} <span style="color:red; font-weight:normal">*</span></th>
       <td><input name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details.</p></td>
     </tr>
     <tr>
-      <th>{{ KNOWL("institution_shortname") }}</th>
+      <th>{{ KNOWL("institution_shortname") }} <span style="color:red; font-weight:normal">*</span></th>
       <td><input name="shortname" style="width:500px;" placeholder="UPan" maxlength="32"/></td>
       <td class="forminfo">Use 2-32 characters, no spaces.
     </tr>


### PR DESCRIPTION
I addressed #83 on the create seminar/institution pages.  I'm pushing to master just so people can see what it looks like.  If people are happy with this look I'll move it into style.css add add it to all the other edit forms as I knowlify the captions (we could get fancier and use an icon rather than an asterisk, but I think the asterisk looks fine.  

I don't think its necessary to tell people the asterisk indicates required fields after the create pages (which is the initial entry point to creating content).