### PR TITLE
Resolves #83, #118, #165 and #166

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -373,6 +373,8 @@ def save_seminar():
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     if not data["name"]:
         errmsgs.append("Seminar name cannot be blank")
+    if seminar.is_conference and data["start_time"] and data["end_time"] and data["end_time"] < data["start_time"]:
+        errmsgs.append("End date cannot precede start date")
     for col in ["frequency", "per_day"]:
         if data[col] is not None and data[col] < 1:
             errmsgs.append(

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -373,7 +373,7 @@ def save_seminar():
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     if not data["name"]:
         errmsgs.append("Seminar name cannot be blank")
-    if seminar.is_conference and data["start_time"] and data["end_time"] and data["end_time"] < data["start_time"]:
+    if seminar.is_conference and data["start_date"] and data["end_date"] and data["end_date"] < data["start_date"]:
         errmsgs.append("End date cannot precede start date")
     for col in ["frequency", "per_day"]:
         if data[col] is not None and data[col] < 1:

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -27,7 +27,7 @@
         <input type="hidden" name="is_conference" value="{% if seminar.is_conference %}yes{% else %}no{% endif %}"/>
       <table>
         <tr>
-          <td style="width:150px;"></td>
+          <td style="width:150px;">{{ KNOWL("seminar_id") }}</td>
           <td>{{ seminar.shortname }}</td>
         </tr>
         <tr>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -44,7 +44,7 @@
           <td><input name="homepage" value="{{ seminar.homepage | blanknone }}" style="width:600px;" placeholder="https://example.org"/></td>
         </tr>
         <tr>
-          <td>{{ KNOWL("seminar_institutions") }}/td>
+          <td>{{ KNOWL("seminar_institutions") }}</td>
           <td><span id="institution_selector" style="width:610px;"></span></td>
         </tr>
         <tr>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -155,11 +155,11 @@
       their name will be linked to their home page, and if homepage is not set but email is set their name will have a mailto link.</p>
       <table>
         <thead>
-          <td align="right">{{ KNOWL("organizer_name") }}</td>
-          <td align="right">{{ KNOWL("homepage") }}</td>
-          <td align="right">{{ KNOWL("email") }}</td>
-          <td align="right">{{ KNOWL("organizer") }}</td>
-          <td align="right">{{ KNOWL("display") }}</td>
+          <td align="center">{{ KNOWL("organizer_name") }}</td>
+          <td align="center">{{ KNOWL("homepage") }}</td>
+          <td align="center">{{ KNOWL("email") }}</td>
+          <td align="center">{{ KNOWL("organizer") }}</td>
+          <td align="center">{{ KNOWL("display") }}</td>
         </thead>
         {% for i in range(10) %}
         <tr>
@@ -173,20 +173,20 @@
             <td>
               <input name="org_email{{i}}" value="{{ seminar.organizer_data[i].get('email') | blanknone }}" style="width:220px"/>
             </td>
-            <td>
+            <td align="center">
               {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}
               {# but it is displayed in a column labeleled "organizer" so it is checked when curator is false #}
               <input type="checkbox" name="org_curator{{i}}" value="yes" {% if not seminar.organizer_data[i].get("curator") %}checked{% endif %} />
             </td>
-            <td>
+            <td align="center">
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizer_data[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
             <td><input name="org_full_name{{i}}" style="width:180px;" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
-            <td align="right"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
-            <td align="right"><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
+            <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
+            <td align="center"><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
           {% endif %}
         </tr>
         {% endfor %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -33,7 +33,7 @@
         <tr>
           <td>{{ ASTKNOWL("seminar_name") }}</td>
           <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" /></td>
-          <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
+          <td class="forminfo" />Capitalize first word and proper nouns.</td>
         </tr>
         <tr>
           <td>{{ KNOWL("seminar_description") }}</td>
@@ -58,13 +58,13 @@
 
         {% if seminar.is_conference %}
         <tr>
-          <td style="padding-top: 20px">{{ ASTKNOWL("start_date") }}</td>
+          <td style="padding-top: 20px">{{ KNOWL("start_date") }}</td>
           <td style="padding-top: 20px">
             <input name="start_date" style="width:600px;" value="{{ seminar.show_input_date(seminar.start_date) }}" style="width:600px;" placeholder="2020-01-27" />
           </td>
         </tr>
         <tr>
-          <td> {{ ASTKNOWL("end_date") }}</td>
+          <td> {{ KNOWL("end_date") }}</td>
           <td>
             <input name="end_date" value="{{ seminar.show_input_date(seminar.end_date) }}" style="width:600px;" placeholder="2020-01-31" />
           </td>
@@ -100,6 +100,7 @@
               {% endfor %}
             </select>
           </td>
+          <td class="forminfo" />Be sure to set this correctly.</td>
         </tr>
         {% if not seminar.is_conference %}
         <tr>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -83,13 +83,13 @@
         </tr>
         <tr>
           <td>{{ KNOWL("frequency", "Frequency (in days)") }}</td>
-          <td><input name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:600px;"/></td>
+          <td><input name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:600px;" placeholder="7"/></td>
         </tr>
         {% endif %}
 
         <tr>
           <td>{{ KNOWL("per_day") }}</td>
-          <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" /></td>
+          <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" placeholder="1"/></td>
         </tr>
         <tr>
           <td>{{ ASTKNOWL("timezone") }}</td>
@@ -114,7 +114,7 @@
         {% endif %}
         <tr>
           <td style="padding-top: 20px">{{ KNOWL("room") }}</td>
-          <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" /></td>
+          <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" placeholder="Room 2-190 in the Simons building"/></td>
         </tr>
         <tr>
           <td>{{ ASTKNOWL("online") }}</td>
@@ -140,17 +140,6 @@
             </select>
           </td>
         </tr>
-        {% if not seminar.new %}
-          <tr>
-            <td>{{ KNOWL("archived") }}</td>
-            <td>
-              <select name="archived" style="width:610px;">
-                <option value="yes"{% if seminar.archived %} selected{% endif %}>yes</option>
-                <option value="no"{% if not seminar.archived %} selected{% endif %}>no</option>
-              </select>
-            </td>
-          </tr>
-        {% endif %}
         <tr>
           <td colspan="2" style="padding-top: 10px">{{ KNOWL("comments") }}</td>
         </tr>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -155,11 +155,11 @@
       their name will be linked to their home page, and if homepage is not set but email is set their name will have a mailto link.</p>
       <table>
         <thead>
-          <th>{{ KNOWL("organizer_name") }}</th>
-          <th>{{ KNOWL("homepage") }}</th>
-          <th>{{ KNOWL("email") }}</th>
-          <th>{{ KNOWL("organizer") }}</th>
-          <th>{{ KNOWL("display") }}</th>
+          <td align="right">{{ KNOWL("organizer_name") }}</td>
+          <td align="right">{{ KNOWL("homepage") }}</td>
+          <td align="right">{{ KNOWL("email") }}</td>
+          <td align="right">{{ KNOWL("organizer") }}</td>
+          <td align="right">{{ KNOWL("display") }}</td>
         </thead>
         {% for i in range(10) %}
         <tr>
@@ -185,8 +185,8 @@
             <td><input name="org_full_name{{i}}" style="width:180px;" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
-            <td><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
-            <td><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
+            <td align="right"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
+            <td align="right"><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
           {% endif %}
         </tr>
         {% endfor %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -52,7 +52,7 @@
           <td><span id="topic_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
-          <td>{{ ASTKNOWL("language","Default language") }}</td>
+          <td>{{ ASTKNOWL("language","Language") }}</td>
           <td><span id="language_selector" style="width:600px;"></span></td>
         </tr>
 
@@ -64,7 +64,7 @@
           </td>
         </tr>
         <tr>
-          <td> {{ ASTKNOWL("end_date) }}</td>
+          <td> {{ ASTKNOWL("end_date") }}</td>
           <td>
             <input name="end_date" value="{{ seminar.show_input_date(seminar.end_date) }}" style="width:600px;" placeholder="2020-01-31" />
           </td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -191,7 +191,8 @@
         </tr>
         {% endfor %}
       </table>
-      <button type="submit" onclick="unsaved = false;return true;">Save</button>
+      <a style="margin-left: 30px; font-weight: bold;" onclick="unsaved = false;" href="{{ url_for('save_seminar', shortname=seminar.shortname) }}">Save changes</a>
+<!--      <button type="submit" onclick="unsaved = false;return true;">Save</button> -->
 
       {% if seminar.new %}
         <a style="margin-left: 30px" onclick="unsaved = false;" href="{{ url_for('create.index') }}">Cancel creation</a>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -112,7 +112,7 @@
         </tr>
         {% endif %}
         <tr>
-          <td style="padding-top: 20px">{{ KNOWL("Room") }}</td>
+          <td style="padding-top: 20px">{{ KNOWL("room") }}</td>
           <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>
@@ -151,7 +151,7 @@
           </tr>
         {% endif %}
         <tr>
-          <td colspan="2" style="padding-top: 10px">Comments</td>
+          <td colspan="2" style="padding-top: 10px">{{ KNOWL("comments") }}</td>
         </tr>
         <tr>
           <td colspan="2"><textarea cols="89" rows="6" style="width:770px;" name="comments">{{ seminar.comments | blanknone }}</textarea></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -92,7 +92,7 @@
           <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>
-          <td>{{ KNOWL("timezone") }}</td>
+          <td>{{ ASTKNOWL("timezone") }}</td>
           <td>
             <select name="timezone" style="width:610px;">
               {% for tz, disp in timezones %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -44,11 +44,11 @@
           <td><input name="homepage" value="{{ seminar.homepage | blanknone }}" style="width:600px;" placeholder="https://example.org"/></td>
         </tr>
         <tr>
-          <td>{{ KNOWL("seminar_institutions") }}</td>
+          <td>{{ KNOWL("institutions") }}</td>
           <td><span id="institution_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
-          <td>{{ KNOWL("seminar_topics") }}</td>
+          <td>{{ KNOWL("topics") }}</td>
           <td><span id="topic_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
@@ -103,16 +103,16 @@
         </tr>
         {% if not seminar.is_conference %}
         <tr>
-          <td>{{ KNOWL("seminar_start time") }}</td>
+          <td>{{ KNOWL("seminar_start_time") }}</td>
           <td><input name="start_time" value="{{ seminar.show_input_time(seminar.start_time) }}" style="width:600px;" placeholder="15:00"/></td>
         </tr>
         <tr>
-          <td>{{ KNOWL("seminar_end time") }}</td>
+          <td>{{ KNOWL("seminar_end_time") }}</td>
           <td><input name="end_time" value="{{ seminar.show_input_time(seminar.end_time) }}" style="width:600px;" placeholder="16:00"/></td>
         </tr>
         {% endif %}
         <tr>
-          <td style="padding-top: 20px">Room</td>
+          <td style="padding-top: 20px">{{ KNOWL("Room") }}</td>
           <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -71,7 +71,7 @@
         </tr>
         {% else %}
         <tr>
-          <td style="padding-top: 20px">{{ KNOWL("weekday")</td>
+          <td style="padding-top: 20px">{{ KNOWL("weekday") }}</td>
           <td style="padding-top: 20px">
             <select name="weekday" style="width:610px;">
               <option value=""></option>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -27,51 +27,51 @@
         <input type="hidden" name="is_conference" value="{% if seminar.is_conference %}yes{% else %}no{% endif %}"/>
       <table>
         <tr>
-          <td style="width:150px;">{{ KNOWL("Identifier") }}</td>
+          <td style="width:150px;"></td>
           <td>{{ seminar.shortname }}</td>
         </tr>
         <tr>
-          <td>Full name</td>
+          <td>{{ ASTKNOWL("seminar_name") }}</td>
           <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" /></td>
           <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
         </tr>
         <tr>
-          <td>Short description</td>
+          <td>{{ KNOWL("seminar_description") }}</td>
           <td><input name="description" value="{{ seminar.description | blanknone }}" style="width:600px;" placeholder="research seminar" maxlength="60"/></td>
         </tr>
         <tr>
-          <td style="white-space:nowrap">External homepage</td>
+          <td>{{ KNOWL("seminar_homepage") }}</td>
           <td><input name="homepage" value="{{ seminar.homepage | blanknone }}" style="width:600px;" placeholder="https://example.org"/></td>
         </tr>
         <tr>
-          <td>Institutions</td>
+          <td>{{ KNOWL("seminar_institutions") }}/td>
           <td><span id="institution_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
-          <td>Topics</td>
+          <td>{{ KNOWL("seminar_topics") }}</td>
           <td><span id="topic_selector" style="width:610px;"></span></td>
         </tr>
         <tr>
-          <td>Default language</td>
+          <td>{{ ASTKNOWL("language","Default language") }}</td>
           <td><span id="language_selector" style="width:600px;"></span></td>
         </tr>
 
         {% if seminar.is_conference %}
         <tr>
-          <td style="padding-top: 20px">Start date</td>
+          <td style="padding-top: 20px">{{ ASTKNOWL("start_date") }}</td>
           <td style="padding-top: 20px">
             <input name="start_date" style="width:600px;" value="{{ seminar.show_input_date(seminar.start_date) }}" style="width:600px;" placeholder="2020-01-27" />
           </td>
         </tr>
         <tr>
-          <td>End date</td>
+          <td> {{ ASTKNOWL("end_date) }}</td>
           <td>
             <input name="end_date" value="{{ seminar.show_input_date(seminar.end_date) }}" style="width:600px;" placeholder="2020-01-31" />
           </td>
         </tr>
         {% else %}
         <tr>
-          <td style="padding-top: 20px">Meeting day</td>
+          <td style="padding-top: 20px">{{ KNOWL("weekday")</td>
           <td style="padding-top: 20px">
             <select name="weekday" style="width:610px;">
               <option value=""></option>
@@ -82,17 +82,17 @@
           </td>
         </tr>
         <tr>
-          <td style="white-space:nowrap">Frequency (in days)</td>
+          <td>{{ KNOWL("frequency", "Frequency (in days)") </td>
           <td><input name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:600px;"/></td>
         </tr>
         {% endif %}
 
         <tr>
-          <td>Talks per day</td>
+          <td>{{ KNOWL("per_day") }}</td>
           <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>
-          <td>Time zone</td>
+          <td>{{ KNOWL("timezone") }}</td>
           <td>
             <select name="timezone" style="width:610px;">
               {% for tz, disp in timezones %}
@@ -103,11 +103,11 @@
         </tr>
         {% if not seminar.is_conference %}
         <tr>
-          <td>Start time</td>
+          <td>{{ KNOWL("seminar_start time") }}</td>
           <td><input name="start_time" value="{{ seminar.show_input_time(seminar.start_time) }}" style="width:600px;" placeholder="15:00"/></td>
         </tr>
         <tr>
-          <td>End time</td>
+          <td>{{ KNOWL("seminar_end time") }}</td>
           <td><input name="end_time" value="{{ seminar.show_input_time(seminar.end_time) }}" style="width:600px;" placeholder="16:00"/></td>
         </tr>
         {% endif %}
@@ -116,7 +116,7 @@
           <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" /></td>
         </tr>
         <tr>
-          <td>Online</td>
+          <td>{{ ASTKNOWL("online") }}</td>
           <td>
             <select name="online" style="width:610px;">
               <option value="yes"{% if seminar.online %} selected{% endif %}>yes</option>
@@ -125,12 +125,12 @@
           </td>
         </tr>
         <tr>
-          <td>Livestream link</td>
+          <td>{{ KNOWL("live_link") }}</td>
           <td><input name="live_link" value="{{ seminar.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />Enter "see comments" if link is not fixed and explain in comments how to the link.</td>
         </tr>
         <tr>
-          <td>Access</td>
+          <td>{{ KNOWL("access") }}</td>
           <td>
             <select name="access" style="width:610px;">
               <option value="open"{% if seminar.access == 'open' %} selected{% endif %}>All visitors can view link</option>
@@ -141,7 +141,7 @@
         </tr>
         {% if not seminar.new %}
           <tr>
-            <td>Archived</td>
+            <td>{{ KNOWL("archived") }}</td>
             <td>
               <select name="archived" style="width:610px;">
                 <option value="yes"{% if seminar.archived %} selected{% endif %}>yes</option>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -191,8 +191,7 @@
         </tr>
         {% endfor %}
       </table>
-      <a style="margin-left: 30px; font-weight: bold;" onclick="unsaved = false;" href="{{ url_for('create.save_seminar') }}">Save changes</a>
-<!--      <button type="submit" onclick="unsaved = false;return true;">Save</button> -->
+      <button type="submit" onclick="unsaved = false;return true;">Save</button>
 
       {% if seminar.new %}
         <a style="margin-left: 30px" onclick="unsaved = false;" href="{{ url_for('create.index') }}">Cancel creation</a>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -33,7 +33,7 @@
         <tr>
           <td>{{ ASTKNOWL("seminar_name") }}</td>
           <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" /></td>
-          <td class="forminfo" />Capitalize first word and proper nouns.</td>
+          <td class="forminfo" />Capitalize only the first word and proper nouns.</td>
         </tr>
         <tr>
           <td>{{ KNOWL("seminar_description") }}</td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -82,7 +82,7 @@
           </td>
         </tr>
         <tr>
-          <td>{{ KNOWL("frequency", "Frequency (in days)") </td>
+          <td>{{ KNOWL("frequency", "Frequency (in days)") }}</td>
           <td><input name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:600px;"/></td>
         </tr>
         {% endif %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -191,7 +191,7 @@
         </tr>
         {% endfor %}
       </table>
-      <a style="margin-left: 30px; font-weight: bold;" onclick="unsaved = false;" href="{{ url_for('save_seminar', shortname=seminar.shortname) }}">Save changes</a>
+      <a style="margin-left: 30px; font-weight: bold;" onclick="unsaved = false;" href="{{ url_for('create.save_seminar', shortname=seminar.shortname) }}">Save changes</a>
 <!--      <button type="submit" onclick="unsaved = false;return true;">Save</button> -->
 
       {% if seminar.new %}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -191,7 +191,7 @@
         </tr>
         {% endfor %}
       </table>
-      <a style="margin-left: 30px; font-weight: bold;" onclick="unsaved = false;" href="{{ url_for('create.save_seminar', shortname=seminar.shortname) }}">Save changes</a>
+      <a style="margin-left: 30px; font-weight: bold;" onclick="unsaved = false;" href="{{ url_for('create.save_seminar') }}">Save changes</a>
 <!--      <button type="submit" onclick="unsaved = false;return true;">Save</button> -->
 
       {% if seminar.new %}

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -35,7 +35,7 @@
   <table id="edit-schedule-table">
     <thead>
       <tr>
-        <td>{{ KNOWL("talk_date") }}</td>
+        <td style="align:center">{{ KNOWL("talk_date") }}</td>
         <td>{{ KNOWL("talk_time_range") }}</td>
         <td>{{ KNOWL("speaker") }}</td>
         <td>{{ KNOWL("speaker_email") }}</td>

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -36,7 +36,7 @@
     <thead>
       <tr>
         <th>{{ KNOWL("talk_date") }}</th>
-        <th>{{ KNOWL("talk_time") }}</th>
+        <th>{{ KNOWL("talk_time_range") }}</th>
         <th>{{ KNOWL("speaker") }}</th>
         <th>{{ KNOWL("speaker_email") }}</th>
         <th>{{ KNOWL("speaker_affiliation") }}</th>

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -35,12 +35,12 @@
   <table id="edit-schedule-table">
     <thead>
       <tr>
-        <th>Date</th>
-        <th>Time</th>
-        <th>Speaker</th>
-        <th>Email</th>
-        <th>Affiliation</th>
-        <th>Title</th>
+        <th>{{ KNOWL("talk_date") }}</th>
+        <th>{{ KNOWL("talk_time") }}</th>
+        <th>{{ KNOWL("speaker") }}</th>
+        <th>{{ KNOWL("speaker_email") }}</th>
+        <th>{{ KNOWL("speaker_affiliation") }}</th>
+        <th>{{ KNOWL("title") }}</th>
         <th></th>
       </tr>
     </thead>

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -40,7 +40,7 @@
         <td align="center">{{ KNOWL("speaker") }}</td>
         <td align="center">{{ KNOWL("speaker_email") }}</td>
         <td align="center">{{ KNOWL("speaker_affiliation") }}</td>
-        <td align="center">{{ KNOWL("title") }}</th>
+        <td align="center">{{ KNOWL("title") }}</td>
         <td></td>
       </tr>
     </thead>

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -35,12 +35,12 @@
   <table id="edit-schedule-table">
     <thead>
       <tr>
-        <td style="align:center">{{ KNOWL("talk_date") }}</td>
-        <td>{{ KNOWL("talk_time_range") }}</td>
-        <td>{{ KNOWL("speaker") }}</td>
-        <td>{{ KNOWL("speaker_email") }}</td>
-        <td>{{ KNOWL("speaker_affiliation") }}</td>
-        <td>{{ KNOWL("title") }}</th>
+        <td align="center">{{ KNOWL("talk_date") }}</td>
+        <td align="center">{{ KNOWL("talk_time_range") }}</td>
+        <td align="center">{{ KNOWL("speaker") }}</td>
+        <td align="center">{{ KNOWL("speaker_email") }}</td>
+        <td align="center">{{ KNOWL("speaker_affiliation") }}</td>
+        <td align="center">{{ KNOWL("title") }}</th>
         <td></td>
       </tr>
     </thead>

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -35,13 +35,13 @@
   <table id="edit-schedule-table">
     <thead>
       <tr>
-        <th>{{ KNOWL("talk_date") }}</th>
-        <th>{{ KNOWL("talk_time_range") }}</th>
-        <th>{{ KNOWL("speaker") }}</th>
-        <th>{{ KNOWL("speaker_email") }}</th>
-        <th>{{ KNOWL("speaker_affiliation") }}</th>
-        <th>{{ KNOWL("title") }}</th>
-        <th></th>
+        <td>{{ KNOWL("talk_date") }}</td>
+        <td>{{ KNOWL("talk_time_range") }}</td>
+        <td>{{ KNOWL("speaker") }}</td>
+        <td>{{ KNOWL("speaker_email") }}</td>
+        <td>{{ KNOWL("speaker_affiliation") }}</td>
+        <td>{{ KNOWL("title") }}</th>
+        <td></td>
       </tr>
     </thead>
     {% set vars = {'i': 0} %}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -20,7 +20,7 @@
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>
-      <td style="width:250px;"></td>
+      <td style="width:300px;"></td>
     </tr>
     <tr>
       <td>{{ KNOWL("topics") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -20,6 +20,7 @@
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>
+      <td style="width:250px;"></td>
     </tr>
     <tr>
       <td>{{ KNOWL("topics") }}</td>
@@ -95,6 +96,7 @@
     <tr>
       <td>{{ KNOWL("speaker_email") }}</td>
       <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" placeholder="someone@upan.edu"/></td>
+      <td class="forminfo" />Visible only to organizers.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_affiliation") }}</td>
@@ -103,11 +105,12 @@
     <tr>
       <td>{{ KNOWL("speaker_homepage") }}</td>
       <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" placeholder="https://upan.edu/~someone"/></td>
+      <td class="forminfo" />Please set if available.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("title") }}</td>
       <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" placeholder="TeX symbols are OK here" /></td>
-      <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
+      <td class="forminfo" />Capitalize first word and proper nouns.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("paper_link") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -20,7 +20,6 @@
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>
-      <td style="width:300px;"></td>
     </tr>
     <tr>
       <td>{{ KNOWL("topics") }}</td>
@@ -110,7 +109,7 @@
     <tr>
       <td>{{ KNOWL("title") }}</td>
       <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" placeholder="TeX symbols are OK here" /></td>
-      <td class="forminfo" />Capitalize first word and proper nouns.</td>
+      <td class="forminfo" />Capitalize only the first word and proper nouns.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("paper_link") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -101,7 +101,7 @@
       <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>{{ KNWOL("speaker_homepage") }}</td>
+      <td>{{ KNOWL("speaker_homepage") }}</td>
       <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -53,7 +53,7 @@
     </tr>
     <tr>
       <td>{{ KNOWL("room") }}</td>
-      <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" /></td>
+      <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" placeholder="Room 2-190 in the Simons building" /></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("online") }}</td>
@@ -90,19 +90,19 @@
   <table>
     <tr>
       <td style="width:150px">{{ KNOWL("speaker") }}</td>
-      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" /></td>
+      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" placeholder="Firstname Lastname"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_email") }}</td>
-      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" /></td>
+      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" placeholder="someone@upan.edu/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_affiliation") }}</td>
-      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" /></td>
+      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" placeholder="University of Pangaea" /></td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_homepage") }}</td>
-      <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" /></td>
+      <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" placeholder="https://upan.edu/~someone"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("title") }}</td>
@@ -111,15 +111,15 @@
     </tr>
     <tr>
       <td>{{ KNOWL("paper_link") }}</td>
-      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:600px;" /></td>
+      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:600px;" placeholder="https://arxiv.org/abs/9999.99999"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("slide_link") }}</td>
-      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:600px;" /></td>
+      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:600px;" placeholder="https://upan.edu/~someone/myslides.pdf"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("video_link") }}</td>
-      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" /></td>
+      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" placeholder="https://www.youtube.com/watch?v=abc123"></td>
     </tr>
   </table>
   <h3>Abstract</h3>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -16,25 +16,25 @@
   <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
   <table>
     <tr>
-      <td style="width:150px;">Seminar</td>
+      <td style="width:150px;">{% if talk.seminar.is_conference %} {{ KNOWL("conference") }} {% else %} {{ KNOWL("seminar") }} {% endif %}</td>
       <td>
         <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>
       </td>
     </tr>
     <tr>
-      <td>Topics</td>
+      <td>{{ KNOWL("topics") }}</td>
       <td>
         <span id="topic_selector" style="width:610px;"></span>
       </td>
     </tr>
     <tr>
-      <td>Language</td>
+      <td>{{ ASTKNOWL("language") }}</td>
       <td>
         <span id="language_selector" style="width:600px;"></span>
       </td>
     </tr>
     <tr>
-      <td>Time zone</td>
+      <td>{{ ASTKNOWL("timezone" }}</td>
       <td>
         <select name="timezone" style="width:610px;">
           {% for tz, disp in timezones %}
@@ -44,19 +44,19 @@
       </td>
     </tr>
     <tr>
-      <td>Start</td>
+      <td>{{ ASTKNOWL("talk_start_time") }}</td>
       <td><input name="start_time" value="{{ talk.editable_start_time() }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>End</td>
+      <td>{{ ASTKNOWL("talk_end_time") }}</td>
       <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Room</td>
+      <td>{{ KNOWL("room") }}</td>
       <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Online</td>
+      <td>{{ ASTKNOWL("online") }}</td>
       <td>
         <select name="online" style="width:610px;">
           <option value="yes"{% if talk.online %} selected{% endif %}>yes</option>
@@ -65,12 +65,12 @@
       </td>
     </tr>
     <tr>
-      <td>Livestream link</td>
+      <td>{{ KNOWL("live_link") }}</td>
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the seminar or talk comments how to get the link.</td>
     </tr>
     <tr>
-      <td>Access</td>
+      <td>{{ KNOWL("access") }}</td>
       <td>
         <select name="access" style="width:610px;">
           <option value="open"{% if talk.access == 'open' %} selected{% endif %}>All visitors can view link</option>
@@ -80,7 +80,7 @@
       </td>
     </tr>
     <tr>
-      <td colspan="2">Comments</td>
+      <td colspan="2">{{ KNOWL("comments") }}</td>
     </tr>
     <tr>
       <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; seminar comments will appear immediately after talk comments.">{{ talk.comments | blanknone }}</textarea></td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -94,7 +94,7 @@
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_email") }}</td>
-      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" placeholder="someone@upan.edu/></td>
+      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" placeholder="someone@upan.edu"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_affiliation") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -34,7 +34,7 @@
       </td>
     </tr>
     <tr>
-      <td>{{ ASTKNOWL("timezone" }}</td>
+      <td>{{ ASTKNOWL("timezone") }}</td>
       <td>
         <select name="timezone" style="width:610px;">
           {% for tz, disp in timezones %}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -89,36 +89,36 @@
   <hr style="width:800px;">
   <table>
     <tr>
-      <td style="width:150px">Speaker</td>
+      <td style="width:150px">{{ KNOWL("speaker") }}</td>
       <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Speaker email</td>
+      <td>{{ KNOWL("speaker_email") }}</td>
       <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Speaker affiliation</td>
+      <td>{{ KNOWL("speaker_affiliation") }}</td>
       <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Speaker homepage</td>
+      <td>{{ KNWOL("speaker_homepage") }}</td>
       <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Title</td>
+      <td>{{ KNOWL("title") }}</td>
       <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" placeholder="TeX symbols are OK here" /></td>
       <td class="forminfo" />Generally, capitalize only the first word and proper names.</td>
     </tr>
     <tr>
-      <td>Paper link</td>
+      <td>{{ KNOWL("paper_link") }}</td>
       <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Slides link</td>
+      <td>{{ KNOWL("slide_link") }}</td>
       <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:600px;" /></td>
     </tr>
     <tr>
-      <td>Video link</td>
+      <td>{{ KNOWL("video_link") }}</td>
       <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" /></td>
     </tr>
   </table>

--- a/seminars/institution.py
+++ b/seminars/institution.py
@@ -100,11 +100,9 @@ class WebInstitution(object):
             db.institutions.upsert({"shortname": self.shortname}, data)
 
     def admin_link(self):
-        userdata = db.users.lookup(self.admin)
-        return '<a href="mailto:%s">%s</a>' % (
-            self.admin,
-            userdata["name"] if userdata["name"] else self.admin,
-        )
+        rec = db.users.lookup(self.admin)
+        link = (rec["homepage"] if rec["homepage"] else ("mailto:%s" % (rec["email"]) if rec["email"] else ""))
+        return '<a href="%s">%s</a>' % (link, rec["name"] if rec["name"] else self.admin)
 
 ### FIXME ###
 # Should always return a WebInstitution object but currently may returna dictionary or WebObject

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -56,10 +56,10 @@ seminar_description:
   contents: |
     A short desciption of your seminar or conference that will be displayed in our search pages along with the name and institutions.
     Here you might indicate, for example, whether this is a research seminar or a learning seminar.  The short desription can be at most 50 characters long.
-institution_homepage:
+seminar_homepage:
   title: Homepage
   contents: |
-    The external homepage of your seminar or conference (if one exists).  This should be a URL beginning with "http://" or "https://" (the latter is preferred, if availalble).
+    The external homepage of your seminar or conference, if one exists.  This should be a URL beginning with "http://" or "https://" (the latter is preferred, if availalble).
 institutions:
   title: Institutions
   contents: |

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -248,4 +248,4 @@ talk_time_range:
     The start and end times of the talk in 24 hour format, separated by a hyphen, for example 10:00-11:00.
     <br><br>
     Use 23:00-01:00 for a talk that starts at 11pm and ends at 1am the next day.
-    Note that 12:30-1:30 denotes a talk that is 13 hours long (you will be warned about talks that last longer than 8 hours), use 12:30-13:30 if you actually want a one hour talk that begins at 12:30 pm.
+    Note that 12:30-1:30 denotes a talk that is 13 hours long (you will be warned about talks that last longer than 8 hours); you probably want to use 12:30-13:30 instead.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -161,7 +161,7 @@ comments:
     to find the room or access the live link.  You can use include links to external pages here.  Any token beginning with
     "http://" or "https://" will automatically appear as a link and you can also use HTML hyperlinks.
     <br><br>
-    When a talk is displayed the comments for **both** the talk and the seminar are displayed; there is no need to repeat information.
+    When a talk is displayed the comments for both the talk and the seminar are displayed; there is no need to repeat information.
     Use the seminar comments for information applicable to every talk and use the talk comments for information specific to that talk.
 organizer_name:
   title: Name

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -246,5 +246,6 @@ talk_time_range:
   title: Time
   contents: |
     The start and end times of the talk in 24 hour format, separated by a hyphen, for example 10:00-11:00.
+    <br><br>
     Use 23:00-01:00 for a talk that starts at 11pm and ends at 1am the next day.
     Note that 12:30-1:30 denotes a talk that is 13 hours long (you will be warned about talks that last longer than 8 hours), use 12:30-13:30 if you actually want a one hour talk that begins at 12:30 pm.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -227,14 +227,18 @@ speaker_homepage:
     We strongly encourage organizers to fill this in, or to have the speaker do so when the enter their title or abstractt using the edit link for this page.
 title:
   title: Title
+  contents: |
     The title of the talk.  As with seminar and conference names, this should be in <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a>,
     with only the first word and proper nouns captilaized.
 paper_link:
   title: Paper link
+  contents: |
     A URL link to a paper related to the talk.
 slide_link:
   title: Slide link
+  contents: |
     A URL link to a slide presentation used in the talk.  This may be set either before or after the talk.
 video_link:
   title: Video link
+  contents: |
     A URL link to a video recording of the talk.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -50,11 +50,115 @@ seminar_name:
   contents: |
     This is the full name of the seminar or conference, to appear on the browse and search pages. It can be changed at any time.
     Like Wikipedia, mathseminars.org uses <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a> for seminar names and talk titles:
-    only the first word and proper nouns should be capitalized. 
+    only the first word and proper nouns should be capitalized.
+seminar_description: 
+  title: Short description
+  contents: |
+    A short desciption of your seminar or conference that will be displayed in our search pages along with the name and institutions.
+    Here you might indicate, for example, whether this is a research seminar or a learning seminar.  The short desription can be at most 50 characters long.
 institutions:
   title: Institutions
   contents: |
     You may associate zero or more institutions to a seminar or conference.   The list of institutions can be changed at any time.
+topics:
+  title: Topics
+  contents: |
+    You may associate zero or more topics to a talk, seminar, or conference.  Each topic correspond to an arXiv subject class (for example "number theory" is <a href="https://arxiv.org/list/math.NT/reccent>math.NT</a>).
+    When a new talk is created, it inherits all the topics of the seminar or conference to which it belongs; these can then be customized for any particular talk.
+    Changing the topics of a seminar or conference has no impact on existing talks, it is relevant only to new talks and to users searching seminars or conferences by topic.
+language:
+  title: Language
+  contents: |
+    Each talk, seminar, and conference has an associated language (English by default).
+    When a new talk is created it inherits the language of its seminar or conference; this can then be changed for any particular talk.
+    Changing the language of a seminar or conference has no impact on existing talks, it is relevant only to new talks and to users searching seminars or conferences by language.
+weekday:
+  title: Meeting day
+  contents: |
+    Set this attribute if your seminar meets on a particular day of the week (even if your seminar does not meet every week).
+    If specified, this value will be used to layout the scheduling grid for adding talks to your seminar.
+    <br><br>
+    We are aware that many seminars meet on two or more particular days each week and plan to support this option in the near future.
+    For the moment we suggest either setting the meeting day to the first day of the week your seminar meets and then editing the dates on the scheduling grid,
+    or not setting the meeting day and setting the frequency to 1, which will give you a scheulding grid with slots for each day.
+frequency:
+  title: Frequency
+  contents: |
+    Specify the frequency of your seminar if it meets at regular intervals(every 7 or 14 days, for example).
+    If your seminar does not meet on a particular day of the week you can set the frequency to 1 to get a scheduling grid with a slot for each day.
+per_day:
+  title: Talks per day
+  contents: |
+    The number of talks you expect to take place each day your seminar or conference meets.
+    This is used only to determine the number of slots to create in your scheduling grid; you can always add more talks on a particular day if you wish.
+start_date:
+  title: Start date
+  contents: |
+    The date on which your conference begins.
+end_date:
+  title: End date
+  contents: |
+    The date on which your conference ends.
+seminar_start_time:
+  title: Start time
+  contents: |
+    The time of day your seminar usually meets, specified in 24 hour format (so 4 or 4:00 is 4AM, use 16:00 for 4PM).
+seminar_end_time:
+  title: End time
+  contents: |
+    The time of day your seminar usually ends, specified in 24 hour format (so 4 or 4:00 is 4AM, use 16:00 for 4PM).
+timezone:
+  title: Timezone
+  contents: |
+    Each talk, seminar, and conference has a timezone that determines how dates and times associated to the event will be interpreted.
+    Even if your event has no particular physical location, you must set this so that we know how to interperet dates and times that you enter.
+    Note that a timezone is in general not the same as a UTC offset, since it takes adjustments for daylight savings time into account,
+    but you can choose UTC as your timezone if you wish.
+    <br><br>
+    Dates and times shown to visitors of mathseminars.org are automatically translated into the taken of their user account or of their
+    computer.  This includes organizers who are adding talks to seminars or conferences; when editing a schedule the timezone of the seminar
+    or conference will be used, but when browsing talks your user timezone will be used.
+room:
+  title: Room
+  contents: |
+    The physical location of a talk, seminar, or conference; leave this blank for events that take place solely online.
+    When a new talk is created the room is copied from the seminar or conference to which it belongs but may then be changed.
+    Note that changing the room of a seminar or conference has no impact on talks that have already been created.
+    You can use the comments to provide detailed instructions and a link to a map to help visitors find the room.
+online:
+  title: Online
+  contents: |
+    If your seminar can be attended online, indicate that here.  Seminars that provide a live feed of a meeting in a physical location should
+    put the location as the Room and set the online option to yes.
+live_link:
+  title: Livestream link
+  contents: |
+    Events taking place online should list the URL of the livestream here.
+    For seminars and conferences, if the livestream link is not the same for each talk you can put "see comments" here and then
+    explain in the comments section how to get the livestream link for each talk.
+    When a new talk is created the livestream link is copied from the seminar or conference to which it belongs and may then be changed.
+    <br><br>
+    If your livestream requires a password you should indicate in the comments how participants can obtain the password.
+access:
+  title: Access
+  contents: |
+    For talks, seminars, and conferences with a livestream link this determines whether the link will be shown to
+    everyone who visits mathseminars.org, only to users  who have created an account on mathseminars.org, or only to endorsed users of mathseminars.org.
+    When a new talk is created the access setting is copied from the seminar or conference to which it belongs and may then be changed.    
+    If the livestream link is not set this value is ignored.
+access:
+  title: Archived
+  contents: |
+    TBA
+access:
+  title: Comments
+  contents: |
+    Use the comments field to add additional information about yout talk, seminar, or conferenee, especially details on how
+    to find the room or access the live link.  You can use include links to external pages here.  Any token beginning with
+    "http://" or "https://" will automatically appear as a link and you can also use HTML hyperlinks.
+    <br><br>
+    When a talk is displayed the comments for **both** the talk and the seminar are displayed, so there is no need to repeat information.
+    Use the seminar comments for information applicable to every talk and the talk comments for information specific to a talk.
 organizer_name:
   title: Name
   contents: |

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -220,7 +220,7 @@ speaker_homepage:
     The homepage of the speaker.
     The speaker name will be linked to the speaker homepage if specified, and this link will appear on our main page for browsing talks.
     This link is useful to visitors of mathseminars.org who may not know the speaker, and it improves the speaker's visibility within the mathematical community.
-    We strongly encourage organizers to fill this in, or to ask the speaker do so when the enter their title or abstract using the edit link for this page.
+    We encourage organizers to fill this in, or to ask the speaker do so when the enter their title or abstract using the edit link for this page.
 title:
   title: Title
   contents: |

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -154,7 +154,7 @@ archived:
   title: Archived
   contents: |
     Use this to indiate that your seminar is no longer meeting.
-access:
+comments:
   title: Comments
   contents: |
     Use the comments field to add additional information about yout talk, seminar, or conferenee, especially details on how

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -240,11 +240,11 @@ video_link:
     A URL link to a video recording of the talk.
 talk_date:
   title: Date
-  content: |
+  contents: |
     The date the talk starts (talks cannot exceed 24 hours in length, but they may start and end on different dates).
 talk_time_range:
   title: Time
-  content: |
+  contents: |
     The start and end times of the talk in 24 hour format, separated by a hyphen, for example 10:00-11:00.
     Use 23:00-01:00 for a talk that starts at 11pm and ends at 1am the next day.
     Note that 12:30-1:30 denotes a talk that is 13 hours long (you will be warned about talks that last longer than 8 hours), use 12:30-13:30 if you actually want a one hour talk that begins at 12:30 pm.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -15,7 +15,7 @@ institution_type:
 institution_homepage:
   title: Homepage
   contents: |
-    The homepage of your institution.  This should be a URL beginning with "http://" or "https://" (the latter is preferred, if availalble).
+    The homepage of your institution.  This should be a URL beginning with "http".
 institution_city:
   title: City
   contents: |
@@ -42,7 +42,7 @@ seminar_shortname:
   title: Identifier
   contents: |
     Each seminar and conference has a unique identifier consisting of 3 to 32 letters, numbers, hyphens, and underscores (no spaces).
-    It will be included in all URL links to the seminar and its associated talks.
+    It will be included in all URLs links for the seminar and its associated talks.
     When you press create, you will be told if the identifier you entered is already in use.
     After creation, the identifier cannot be changed.
 seminar_id:
@@ -63,7 +63,7 @@ seminar_description:
 seminar_homepage:
   title: Homepage
   contents: |
-    The external homepage of your seminar or conference, if one exists.  This should be a URL beginning with "http://" or "https://" (the latter is preferred, if availalble).
+    The external homepage of your seminar or conference, if one exists.  This should be a URL beginning with "http".
 institutions:
   title: Institutions
   contents: |
@@ -198,4 +198,43 @@ conference:
   title: Conference
   contents: |
     The name of the conference to which this talk belongs.
-
+talk_start_time:
+  title: Start
+  contents: |
+    The time this talk starts in the time zone specified above.
+talk_end_time:
+  title: End
+  contents: |
+    The time this talk ends in the time zone specified above.
+speaker:
+  title: Speaker
+  contents: |
+    The full name of the speaker for this talk.
+speaker_email:
+  title: Speaker email
+  contents: |
+    The email address of the speaker for this talk.  This is only visible to organizers of the seminar or conference to which the talk belongs.
+speaker_affiliation:
+  title: Speaker affiliation
+  contents: |
+    The affiliation of the speaker.  This need not be an institution listed on mathseminars.org.
+speaker_homepage:
+  title: Speaker homepage
+  contents: |
+    The homepage of the speaker.  This should be a URL beggining with "http".
+    The speaker name will be linked to the speaker homepage if specified and will appear on the main browse page.
+    This is useful to visitors of mathseminars.org who may not know the speaker and it helps to improve the speaker's visibility to the mathematical community.
+    We strongly encourage organizers to fill this in, or to have the speaker do so when the enter their title or abstractt using the edit link for this page.
+title:
+  title: Title
+    The title of the talk.  As with seminar and conference names, this should be in <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a>,
+    with only the first word and proper nouns captilaized.
+paper_link:
+  title: Paper link
+    A URL link to a paper related to the talk.
+slide_link:
+  title: Slide link
+    A URL link to a slide presentation used in the talk.  This may be set either before or after the talk.
+video_link:
+  title: Video link
+    A URL link to a video recording of the talk.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -67,7 +67,7 @@ institutions:
 topics:
   title: Topics
   contents: |
-    You may associate zero or more topics to a talk, seminar, or conference.  Each topic correspond to an arXiv subject class (for example "number theory" is <a href="https://arxiv.org/list/math.NT/reccent>math.NT</a>).
+    You may associate zero or more topics to a talk, seminar, or conference.  Each topic corresponds to an arXiv subject class; for example number theory is <a href="https://arxiv.org/list/math.NT/reccent">math.NT</a>.
     When a new talk is created, it inherits all the topics of the seminar or conference to which it belongs; these can then be customized for any particular talk.
     Changing the topics of a seminar or conference has no impact on existing talks, it is relevant only to new talks and to users searching seminars or conferences by topic.
 language:

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -45,6 +45,10 @@ seminar_shortname:
     It will be included in all URL links to the seminar and its associated talks.
     When you press create, you will be told if the identifier you entered is already in use.
     After creation, the identifier cannot be changed.
+seminar_id:
+  title: Identifier
+  contents: |
+    The unique identifier of this seminar or conference on mathseminars.org.  This cannot be changed.
 seminar_name:
   title: Name
   contents: |
@@ -186,3 +190,12 @@ display:
   title: Display
   contents: |
     Check this box for oragnizers (or curators) whose names should appear on the seminar's home page.  This box must be checked for at least one organizer or curator.
+seminar:
+  title: Seminar
+  contents: |
+    The name of the seminar to which this talk belongs.
+conference:
+  title: Conference
+  contents: |
+    The name of the conference to which this talk belongs.
+

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -67,7 +67,7 @@ institutions:
 topics:
   title: Topics
   contents: |
-    You may associate zero or more topics to a talk, seminar, or conference.  Each topic corresponds to an arXiv subject class; for example number theory is <a href="https://arxiv.org/list/math.NT/reccent">math.NT</a>.
+    You may associate zero or more topics to a talk, seminar, or conference.  Each topic corresponds to an arXiv subject class; for example number theory is <a href="https://arxiv.org/list/math.NT/recent">math.NT</a>.
     When a new talk is created, it inherits all the topics of the seminar or conference to which it belongs; these can then be customized for any particular talk.
     Changing the topics of a seminar or conference has no impact on existing talks, it is relevant only to new talks and to users searching seminars or conferences by topic.
 language:

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -72,33 +72,33 @@ topics:
   title: Topics
   contents: |
     You may associate zero or more topics to a talk, seminar, or conference.  Each topic corresponds to an arXiv subject class; for example number theory is <a href="https://arxiv.org/list/math.NT/recent">math.NT</a>.
-    When a new talk is created, it inherits all the topics of the seminar or conference to which it belongs; these can then be customized for any particular talk.
-    Changing the topics of a seminar or conference has no impact on existing talks, it is relevant only to new talks and to users searching seminars or conferences by topic.
+    New talks inherit the topics of the seminar or conference to which they belong; these can then be modified for a particular talk if desired.
+    Changing the topics of a seminar or conference has no impact on existing talks.
 language:
   title: Language
   contents: |
-    Each talk, seminar, and conference has an associated language (English by default).
-    When a new talk is created it inherits the language of its seminar or conference; this can then be changed for any particular talk.
-    Changing the language of a seminar or conference has no impact on existing talks, it is relevant only to new talks and to users searching seminars or conferences by language.
+    Each talk, seminar, and conference has an associated language (English is the default).
+    New talks inherit the language of the seminar or conference to which they belong; this can then be modified for a particular talk if desired.
+    Changing the language of a seminar or conference has no impact on existing talks.
 weekday:
   title: Meeting day
   contents: |
-    Set this attribute if your seminar meets on a particular day of the week (even if your seminar does not meet every week).
-    If specified, this value will be used to layout the scheduling grid for adding talks to your seminar.
+    Set this if your seminar meets on a particular day of the week, even if your seminar does not meet every week.
+    If specified, this value will be used to layout the grid used editing the schedule of talks for your seminar.
     <br><br>
-    We are aware that many seminars meet on two or more particular days each week and plan to support this option in the near future.
-    For the moment we suggest either setting the meeting day to the first day of the week your seminar meets and then editing the dates on the scheduling grid,
+    For seminars that meet more than one day per week we suggest either setting the meeting day to the first day of the week your seminar meets and then editing the dates on the scheduling grid,
     or not setting the meeting day and setting the frequency to 1, which will give you a scheulding grid with slots for each day.
+    We are currently working on features to better support seminars that meet on multiple days.
 frequency:
   title: Frequency
   contents: |
-    Specify the frequency of your seminar if it meets at regular intervals(every 7 or 14 days, for example).
-    If your seminar does not meet on a particular day of the week you can set the frequency to 1 to get a scheduling grid with a slot for each day.
+    Specify the frequency of your seminar if it meets at regular intervals, every 7 or 14 days, for example.
+    If your seminar does not meet on a particular day of the week you can set the frequency to 1; this will yielda scheduling grid with slots for each day.
 per_day:
   title: Talks per day
   contents: |
     The number of talks you expect to take place each day your seminar or conference meets.
-    This is used only to determine the number of slots to create in your scheduling grid; you can always add more talks on a particular day if you wish.
+    This is used only to determine the number of slots to create in your scheduling grid; you can still add more talks on a particular day if you wish.
 start_date:
   title: Start date
   contents: |
@@ -110,54 +110,50 @@ end_date:
 seminar_start_time:
   title: Start time
   contents: |
-    The time of day your seminar usually meets, specified in 24 hour format (so 4 or 4:00 is 4AM, use 16:00 for 4PM).
+    The time of day your seminar usually meets, specified in 24 hour format (so 4 or 4:00 is 4AM; use 16:00 for 4PM).
 seminar_end_time:
   title: End time
   contents: |
-    The time of day your seminar usually ends, specified in 24 hour format (so 4 or 4:00 is 4AM, use 16:00 for 4PM).
+    The time of day your seminar usually ends, specified in 24 hour format (so 4 or 4:00 is 4AM; use 16:00 for 4PM).
 timezone:
   title: Timezone
   contents: |
-    Each talk, seminar, and conference has a timezone that determines how dates and times associated to the event will be interpreted.
-    Even if your event has no particular physical location, you must set this so that we know how to interperet dates and times that you enter.
-    Note that a timezone is in general not the same as a UTC offset, since it takes adjustments for daylight savings time into account,
+    Each talk, seminar, and conference has a timezone that determines how dates and times associated to the event are interpreted.
+    Even if your event has no particular physical location, you must set the timezone so that we know how to interperet dates and times that you input.
+    Note that a timezone is in general not the same as a UTC offset, it takes adjustments for daylight savings time into account,
     but you can choose UTC as your timezone if you wish.
     <br><br>
-    Dates and times shown to visitors of mathseminars.org are automatically translated into the taken of their user account or of their
-    computer.  This includes organizers who are adding talks to seminars or conferences; when editing a schedule the timezone of the seminar
-    or conference will be used, but when browsing talks your user timezone will be used.
+    Dates and times shown to visitors of mathseminars.org are translated into their local timezone, as specified in their user account or on their computer.
+    This includes organizers, so when editing a schedule the timezone of the seminar or conference will be used to interpret your inputs, but when browsing talks
+    your local timezone will be used.
 room:
   title: Room
   contents: |
     The physical location of a talk, seminar, or conference; leave this blank for events that take place solely online.
-    When a new talk is created the room is copied from the seminar or conference to which it belongs but may then be changed.
+    New talks inherit the room of the seminar or conference to which they belong; this can then be modified for a particular talk if desired.
     Note that changing the room of a seminar or conference has no impact on talks that have already been created.
-    You can use the comments to provide detailed instructions and a link to a map to help visitors find the room.
+    <br><br>
+    Use the comments to provide any specific instructions to help visitors find the room (you can include a link to a campus map, for example).
 online:
   title: Online
   contents: |
-    If your seminar can be attended online, indicate that here.  Seminars that provide a live feed of a meeting in a physical location should
-    put the location as the Room and set the online option to yes.
+    If your seminar can be attended online, indicate that here.  Seminars that provide a livestream of a meeting taking place in a physical location should
+    set the location in the Room property and set the online option to yes.
 live_link:
   title: Livestream link
   contents: |
     Events taking place online should list the URL of the livestream here.
-    For seminars and conferences, if the livestream link is not the same for each talk you can put "see comments" here and then
-    explain in the comments section how to get the livestream link for each talk.
-    When a new talk is created the livestream link is copied from the seminar or conference to which it belongs and may then be changed.
+    For seminars and conferences, if the livestream link is not the same for each talk, put "see comments" here and explain in the comments how to get
+    the livestream link for each talk.
+    New talks inherit the livestream link of the seminar or conference to which they belong; this can then be modified for a particular talk if desired.
     <br><br>
-    If your livestream requires a password you should indicate in the comments how participants can obtain the password.
+    If your livestream requires a password you should indicate in the comments how participants should obtain the password.
 access:
   title: Access
   contents: |
     For talks, seminars, and conferences with a livestream link this determines whether the link will be shown to
-    everyone who visits mathseminars.org, only to users  who have created an account on mathseminars.org, or only to endorsed users of mathseminars.org.
-    When a new talk is created the access setting is copied from the seminar or conference to which it belongs and may then be changed.    
-    If the livestream link is not set this value is ignored.
-archived:
-  title: Archived
-  contents: |
-    Use this to indiate that your seminar is no longer meeting.
+    everyone who visits mathseminars.org, only to users who are logged in to an account on mathseminars.org, or only to endorsed users of mathseminars.org.
+    If the livestream link is not specified this setting is ignored.
 comments:
   title: Comments
   contents: |
@@ -165,12 +161,12 @@ comments:
     to find the room or access the live link.  You can use include links to external pages here.  Any token beginning with
     "http://" or "https://" will automatically appear as a link and you can also use HTML hyperlinks.
     <br><br>
-    When a talk is displayed the comments for **both** the talk and the seminar are displayed, so there is no need to repeat information.
-    Use the seminar comments for information applicable to every talk and the talk comments for information specific to a talk.
+    When a talk is displayed the comments for **both** the talk and the seminar are displayed; there is no need to repeat information.
+    Use the seminar comments for information applicable to every talk and use the talk comments for information specific to that talk.
 organizer_name:
   title: Name
   contents: |
-    The full name of the organizer (or curator) that will be displayed on the seminar's home page.  This cannot be left blank.
+    The full name of the organizer (or curator) that will be displayed on mathseminars.org.  This cannot be left blank.
 homepage:
   title: Homepage
   contents: |
@@ -209,11 +205,11 @@ talk_end_time:
 speaker:
   title: Speaker
   contents: |
-    The full name of the speaker for this talk.
+    The full name of the speaker.
 speaker_email:
   title: Speaker email
   contents: |
-    The email address of the speaker for this talk.  This is only visible to organizers of the seminar or conference to which the talk belongs.
+    The email address of the speaker.  This is only visible to organizers of the seminar or conference to which the talk belongs.
 speaker_affiliation:
   title: Speaker affiliation
   contents: |
@@ -221,10 +217,10 @@ speaker_affiliation:
 speaker_homepage:
   title: Speaker homepage
   contents: |
-    The homepage of the speaker.  This should be a URL beggining with "http".
-    The speaker name will be linked to the speaker homepage if specified and will appear on the main browse page.
-    This is useful to visitors of mathseminars.org who may not know the speaker and it helps to improve the speaker's visibility to the mathematical community.
-    We strongly encourage organizers to fill this in, or to have the speaker do so when the enter their title or abstractt using the edit link for this page.
+    The homepage of the speaker.
+    The speaker name will be linked to the speaker homepage if specified, and this link will appear on our main page for browsing talks.
+    This link is useful to visitors of mathseminars.org who may not know the speaker, and it improves the speaker's visibility within the mathematical community.
+    We strongly encourage organizers to fill this in, or to ask the speaker do so when the enter their title or abstract using the edit link for this page.
 title:
   title: Title
   contents: |
@@ -242,3 +238,13 @@ video_link:
   title: Video link
   contents: |
     A URL link to a video recording of the talk.
+talk_date:
+  title: Date
+  content: |
+    The date the talk starts (talks cannot exceed 24 hours in length, but they may start and end on different dates).
+talk_time_range:
+  title: Time
+  content: |
+    The start and end times of the talk in 24 hour format, separated by a hyphen, for example 10:00-11:00.
+    Use 23:00-01:00 for a talk that starts at 11pm and ends at 1am the next day.
+    Note that 12:30-1:30 denotes a talk that is 13 hours long (you will be warned about talks that last longer than 8 hours), use 12:30-13:30 if you actually want a one hour talk that begins at 12:30 pm.

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -56,6 +56,10 @@ seminar_description:
   contents: |
     A short desciption of your seminar or conference that will be displayed in our search pages along with the name and institutions.
     Here you might indicate, for example, whether this is a research seminar or a learning seminar.  The short desription can be at most 50 characters long.
+institution_homepage:
+  title: Homepage
+  contents: |
+    The external homepage of your seminar or conference (if one exists).  This should be a URL beginning with "http://" or "https://" (the latter is preferred, if availalble).
 institutions:
   title: Institutions
   contents: |
@@ -146,10 +150,10 @@ access:
     everyone who visits mathseminars.org, only to users  who have created an account on mathseminars.org, or only to endorsed users of mathseminars.org.
     When a new talk is created the access setting is copied from the seminar or conference to which it belongs and may then be changed.    
     If the livestream link is not set this value is ignored.
-access:
+archived:
   title: Archived
   contents: |
-    TBA
+    Use this to indiate that your seminar is no longer meeting.
 access:
   title: Comments
   contents: |

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -19,6 +19,8 @@ short_weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
 
 def validate_url(x):
+    if not (x.startswith("http://") or x.startswith("https://")):
+        return false
     try:
         result = urlparse(x)
         return all([result.scheme, result.netloc])
@@ -29,10 +31,8 @@ def make_links(x):
     """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
     tokens = x.split(' ')
     for i in range(len(tokens)):
-        if tokens[i].startswith("https://"):
-            tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][8:])
-        if tokens[i].startswith("http://"):
-            tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][7:])
+        if validate_url(tokens[i]):
+            tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][tokens[i].index("//")+2:])
     return ' '.join(tokens)
 
 def naive_utcoffset(tz):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -29,7 +29,7 @@ def validate_url(x):
 
 def make_links(x):
     """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
-    tokens = re.split(r'(\s+)',x))
+    tokens = re.split(r'(\s+)',x)
     for i in range(len(tokens)):
         if validate_url(tokens[i]):
             tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][tokens[i].index("//")+2:])

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -20,7 +20,7 @@ short_weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 
 def validate_url(x):
     if not (x.startswith("http://") or x.startswith("https://")):
-        return false
+        return False
     try:
         result = urlparse(x)
         return all([result.scheme, result.netloc])

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -29,7 +29,7 @@ def validate_url(x):
 
 def make_links(x):
     """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
-    tokens = x.split('')
+    tokens = x.split()
     for i in range(len(tokens)):
         if validate_url(tokens[i]):
             tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][tokens[i].index("//")+2:])

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -29,11 +29,11 @@ def validate_url(x):
 
 def make_links(x):
     """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
-    tokens = x.split()
+    tokens = re.split(r'(\s+)',x))
     for i in range(len(tokens)):
         if validate_url(tokens[i]):
             tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][tokens[i].index("//")+2:])
-    return ' '.join(tokens)
+    return ''.join(tokens)
 
 def naive_utcoffset(tz):
     if isinstance(tz, str):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -29,7 +29,7 @@ def validate_url(x):
 
 def make_links(x):
     """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
-    tokens = x.split(' ')
+    tokens = x.split('')
     for i in range(len(tokens)):
         if validate_url(tokens[i]):
             tokens[i] = '<a href="%s">%s</a>'%(tokens[i], tokens[i][tokens[i].index("//")+2:])


### PR DESCRIPTION
This add knowls to all the captions on the edit seminar, schedule seminar, and edit talk pages, adds asterisks for required items, and fixes the two bugs Bjorn just reported (#165 and #166).

The knowls could definitely use some proof-reading; I will push this to master to make that easier.

I changed all the knowls to be non-bold (including the column headers), which I think looks better.