### PR TITLE
Require at least one contact for each seminar

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -421,7 +421,7 @@ def save_seminar():
                     "error",
                 )
             if D["email"]:
-                if db.users.lookup(D["email)
+                if db.users.lookup(D["email):
                 if r and r["email_confirmed"]:
                     if D["full_name"] != r["name"]:
                         errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -435,9 +435,10 @@ def save_seminar():
     if contact_count == 0:
         errmsgs.append(
             format_errmsg(
-                "At least one displayed organizer or curator needs a %s so that there is a contact for this listing.<br>%s",
+                "There must be at least one displayed organizer or curator with a %s so that there is a contact for this listing.<br>%s<br>%s",
                 "confirmed email",
                 "This email will not be visible if homepage is set or display is not checked, it is used only to identify the organizer's account.",
+                "If none of the organizers has a confirmed account, add yourself and leave the organizer box unchecked (this will make you a curator.",
             )
         )
     # Don't try to create new_version using invalid input

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -425,8 +425,8 @@ def save_seminar():
             if D["email"]:
                 r = db.users.lookup(D["email"])
                 if r and r["email_confirmed"]:
-                    if D["name"] != r["name"]:
-                        errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["name"], r["name"], D["email"]))
+                    if D["full_name"] != r["name"]:
+                        errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["tull_name"], r["name"], D["email"]))
                     else:
                         contact_count += 1
                         if D["homepage"] and D["homepage"] != r["homepage"]:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -366,9 +366,9 @@ def save_seminar():
             typ = "time"
         try:
             val = raw_data.get(col, "")
-            data[col] = None # make sure col is present even if process_user_input fails
+            data[col] = None  # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
-        except Exception as err: # should only be ValueError's but let's be cautious
+        except Exception as err:  # should only be ValueError's but let's be cautious
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     if not data["name"]:
         errmsgs.append("Seminar name cannot be blank")
@@ -398,9 +398,9 @@ def save_seminar():
             typ = db.seminar_organizers.col_type[col]
             try:
                 val = raw_data.get(name, "")
-                D[col] = None # make sure col is present even if process_user_input fails
+                D[col] = None  # make sure col is present even if process_user_input fails
                 D[col] = process_user_input(val, col, typ, tz)
-            except Exception as err: # should only be ValueError's but let's be cautious
+            except Exception as err:  # should only be ValueError's but let's be cautious
                 errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
@@ -424,10 +424,24 @@ def save_seminar():
                 r = db.users.lookup(D["email"])
                 if r and r["email_confirmed"]:
                     if D["full_name"] != r["name"]:
-                        errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))
+                        errmsgs.append(
+                            format_errmsg(
+                                "Organizer name %s does not match the name %s of the account with email address %s",
+                                D["full_name"],
+                                r["name"],
+                                D["email"],
+                            )
+                        )
                     else:
                         if D["homepage"] and r["homepage"] and D["homepage"] != r["homepage"]:
-                            format_warning("The hompage %s does not match the homepage %s of the account with email address %s", D["homepage"], r["homepage"], D["email"])
+                            flash(
+                                format_warning(
+                                    "The hompage %s does not match the homepage %s of the account with email address %s",
+                                    D["homepage"],
+                                    r["homepage"],
+                                    D["email"],
+                                )
+                            )
                         if D["display"]:
                             contact_count += 1
 
@@ -507,7 +521,7 @@ def save_institution():
         typ = db.institutions.col_type[col]
         try:
             val = raw_data.get(col, "")
-            data[col] = None # make sure col is present even if process_user_input fails
+            data[col] = None  # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
             if col == "admin":
                 userdata = userdb.lookup(data[col])
@@ -518,7 +532,7 @@ def save_institution():
                         errmsgs.append(format_errmsg("user %s does not have an account on this site", data[col]))
                 elif not userdata["creator"]:
                     errmsgs.append(format_errmsg("user %s has not been endorsed", data[col]))
-        except Exception as err: # should only be ValueError's but let's be cautious
+        except Exception as err:  # should only be ValueError's but let's be cautious
             errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
     if not data["name"]:
         errmsgs.append("Institution name cannot be blank.")
@@ -627,11 +641,11 @@ def save_talk():
         typ = db.talks.col_type[col]
         try:
             val = raw_data.get(col, "")
-            data[col] = None # make sure col is present even if process_user_input fails
+            data[col] = None  # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
             if col == "access" and data[col] not in ["open", "users", "endorsed"]:
                 errmsgs.append(format_errmsg("access type %s invalid", data[col]))
-        except Exception as err: # should only be ValueError's but let's be cautious
+        except Exception as err:  # should only be ValueError's but let's be cautious
             errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
     if not data["speaker"]:
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
@@ -838,7 +852,11 @@ def save_seminar_schedule():
             if not warned and any(raw_data.get("%s%s" % (col, i), "").strip() for col in optional_cols):
                 warned = True
                 flash_warning("Talks are only saved if you specify a speaker")
-            elif not warned and seminar_ctr and not any(raw_data.get("%s%s" % (col, i), "").strip() for col in optional_cols):
+            elif (
+                not warned
+                and seminar_ctr
+                and not any(raw_data.get("%s%s" % (col, i), "").strip() for col in optional_cols)
+            ):
                 warned = True
                 flash_warning("To delete an existing talk, click Details and then click delete on the Edit talk page")
             continue
@@ -846,7 +864,7 @@ def save_seminar_schedule():
         if date:
             try:
                 date = process_user_input(date, "date", "date", tz)
-            except Exception as err: # should only be ValueError's but let's be cautious
+            except Exception as err:  # should only be ValueError's but let's be cautious
                 errmsgs.append(format_errmsg("Unable to process input %s for date: {0}".format(err), date))
         else:
             errmsgs.append(format_errmsg("You must specify a date for the talk by %s", speaker))
@@ -903,7 +921,7 @@ def save_seminar_schedule():
             typ = db.talks.col_type[col]
             try:
                 val = raw_data.get("%s%s" % (col, i), "")
-                data[col] = None # make sure col is present even if process_user_input fails
+                data[col] = None  # make sure col is present even if process_user_input fails
                 data[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
                 errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -421,7 +421,8 @@ def save_seminar():
                     "error",
                 )
             if D["email"]:
-                if db.users.count({'email':D["email"], 'email_confirmed':True}):
+                if db.users.lookup(D["email)
+                if r and r["email_confirmed"]:
                     if D["full_name"] != r["name"]:
                         errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))
                     else:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -388,7 +388,7 @@ def save_seminar():
         # Set time zone from institution
         data["timezone"] = WebInstitution(data["institutions"][0]).timezone
     organizer_data = []
-    display_count = email_count = 0
+    display_count = contact_count = 0
     for i in range(10):
         D = {"seminar_id": seminar.shortname}
         for col in db.seminar_organizers.search_cols:
@@ -423,11 +423,18 @@ def save_seminar():
                     "error",
                 )
             if D["email"]:
-                email_count += 1
+                r = db.users.lookup(D["email"])
+                if r and r["email_confirmed"]:
+                    if D["name"] != r["name"]:
+                        errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["name"], r["name"], D["email"]))
+                    else:
+                        contact_count += 1
+                        if D["homepage"] and D["homepage"] != r["homepage"]:
+                            format_warning("The hompage %s does not match the homepage %s of the account with email address %s", D["homepage"], r["homepage"], D["email"])
             organizer_data.append(D)
     if display_count == 0:
         errmsgs.append(format_errmsg("At least one organizer or curator must be displayed."))
-    if email_count == 0:
+    if contact_count == 0:
         errmsgs.append(
             format_errmsg(
                 "At least one organizer or curator needs %s set to ensure that someone can maintain this listing.<br>%s",

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -436,7 +436,7 @@ def save_seminar():
                         if D["homepage"] and r["homepage"] and D["homepage"] != r["homepage"]:
                             flash(
                                 format_warning(
-                                    "The hompage %s does not match the homepage %s of the account with email address %s",
+                                    "The hompage %s does not match the homepage %s of the account with email address %s, please correct if unintended.",
                                     D["homepage"],
                                     r["homepage"],
                                     D["email"],

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -426,7 +426,7 @@ def save_seminar():
                 r = db.users.lookup(D["email"])
                 if r and r["email_confirmed"]:
                     if D["full_name"] != r["name"]:
-                        errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["tull_name"], r["name"], D["email"]))
+                        errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))
                     else:
                         contact_count += 1
                         if D["homepage"] and D["homepage"] != r["homepage"]:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -421,8 +421,7 @@ def save_seminar():
                     "error",
                 )
             if D["email"]:
-                r = db.users.lookup(D["email"])
-                if r and r["email_confirmed"]:
+                if db.users.count({'email':D["email"], 'email_confirmed':True}):
                     if D["full_name"] != r["name"]:
                         errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))
                     else:
@@ -438,7 +437,7 @@ def save_seminar():
                 "There must be at least one displayed organizer or curator with a %s so that there is a contact for this listing.<br>%s<br>%s",
                 "confirmed email",
                 "This email will not be visible if homepage is set or display is not checked, it is used only to identify the organizer's account.",
-                "If none of the organizers has a confirmed account, add yourself and leave the organizer box unchecked (this will make you a curator.",
+                "If none of the organizers has a confirmed account, add yourself and leave the organizer box unchecked.",
             )
         )
     # Don't try to create new_version using invalid input

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -388,7 +388,7 @@ def save_seminar():
         # Set time zone from institution
         data["timezone"] = WebInstitution(data["institutions"][0]).timezone
     organizer_data = []
-    display_count = contact_count = 0
+    contact_count = 0
     for i in range(10):
         D = {"seminar_id": seminar.shortname}
         for col in db.seminar_organizers.search_cols:
@@ -410,8 +410,6 @@ def save_seminar():
             # but it sets the database column curator, so the
             # boolean needs to be inverted
             D["curator"] = not D["curator"]
-            if D["display"]:
-                display_count += 1
             if not errmsgs and D["display"] and D["email"] and not D["homepage"]:
                 flash(
                     format_warning(
@@ -428,18 +426,18 @@ def save_seminar():
                     if D["full_name"] != r["name"]:
                         errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))
                     else:
-                        contact_count += 1
                         if D["homepage"] and r["homepage"] and D["homepage"] != r["homepage"]:
                             format_warning("The hompage %s does not match the homepage %s of the account with email address %s", D["homepage"], r["homepage"], D["email"])
+                        if D["dsiplay"]:
+                            contact_count += 1
+
             organizer_data.append(D)
-    if display_count == 0:
-        errmsgs.append(format_errmsg("At least one organizer or curator must be displayed."))
     if contact_count == 0:
         errmsgs.append(
             format_errmsg(
-                "At least one organizer or curator needs %s set to ensure that someone can maintain this listing.<br>%s",
-                "email",
-                "Note that the email will not be public if homepage is set or display is not checked, it is used only to identify the organizer.",
+                "At least one displayed organizer or curator needs a %s so that there is a contact for this listing.<br>%s",
+                "confirmed email",
+                "This email will not be visible if homepage is set or display is not checked, it is used only to identify the organizer's account.",
             )
         )
     # Don't try to create new_version using invalid input

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -428,7 +428,7 @@ def save_seminar():
                     else:
                         if D["homepage"] and r["homepage"] and D["homepage"] != r["homepage"]:
                             format_warning("The hompage %s does not match the homepage %s of the account with email address %s", D["homepage"], r["homepage"], D["email"])
-                        if D["dsiplay"]:
+                        if D["display"]:
                             contact_count += 1
 
             organizer_data.append(D)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -429,7 +429,7 @@ def save_seminar():
                         errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))
                     else:
                         contact_count += 1
-                        if D["homepage"] and D["homepage"] != r["homepage"]:
+                        if D["homepage"] and r["homepage"] and D["homepage"] != r["homepage"]:
                             format_warning("The hompage %s does not match the homepage %s of the account with email address %s", D["homepage"], r["homepage"], D["email"])
             organizer_data.append(D)
     if display_count == 0:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -421,7 +421,7 @@ def save_seminar():
                     "error",
                 )
             if D["email"]:
-                if db.users.lookup(D["email):
+                r = db.users.lookup(D["email"])
                 if r and r["email_confirmed"]:
                     if D["full_name"] != r["name"]:
                         errmsgs.append(format_errmsg("Organizer name %s does not match the name %s of the account with email address %s", D["full_name"], r["name"], D["email"]))

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -117,7 +117,7 @@
     <tr>
       <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; any seminar comments shown below will appear in additiona to the comments you put here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
-    {% if talk.seminar.comments *}
+    {% if talk.seminar.comments %}
     <hr>
     <tr>
       <td colspan="2">{{ talk.seminar.show_comments() | safe }}<td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -75,7 +75,7 @@
     <tr>
       <td>{{ KNOWL("live_link") }}</td>
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
-          <td class="forminfo" />Enter "see comments" if the link is not fixed and explain in the seminar or talk comments how to get the link.</td>
+          <td class="forminfo" />Enter "see comments" if the link is not fixed and put access instructions in comments.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("access") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -119,10 +119,7 @@
     </tr>
     {% if talk.seminar.comments %}
     <tr>
-      <td colspan="2">{{ KNOWL("comments","Seminar comments") }}</td>
-    </tr>
-    <tr>
-      <td colspan="2">{{ talk.seminar.show_comments() | safe }}<td>
+      <td colspan="2" style="width:770px;">{{ talk.seminar.show_comments() | safe }}<td>
     </tr>
     {% else %}
       <td colspan="2" class="forminfo">No seminar comments set</td>    

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -118,7 +118,7 @@
       <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; any seminar comments shown below will appear in additiona to the comments you put here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
     {% if talk.seminar.comments %}
-      <tr><td colspan="2" class="forminfo">No seminar comments set</td></tr>
+      <tr><td colspan="2" class="forminfo">Seminar comments appear below</td></tr>
       <tr><td colspan="2" style="width:770px;">{{ talk.seminar.show_comments() | safe }}<td></tr>
     {% else %}
       <tr><td colspan="2" class="forminfo">No seminar comments set</td></tr

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -115,12 +115,14 @@
       <td colspan="2">{{ KNOWL("comments") }}</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; seminar comments below will appear in additiona to talk specific comments.">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; any seminar comments shown below will appear in additiona to the comments you put here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
+    {% if talk.seminar.comments *}
     <hr>
     <tr>
-      {{ talk.seminar.show_comments() | safe }}
+      <td colspan="2">{{ talk.seminar.show_comments() | safe }}<td>
     </tr>
+    {% endif %}
   </table>
   <hr style="width:800px;">
   <table>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -115,7 +115,11 @@
       <td colspan="2">{{ KNOWL("comments") }}</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; seminar comments will appear immediately after talk comments.">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; seminar comments below will appear in additiona to talk specific comments.">{{ talk.comments | blanknone }}</textarea></td>
+    </tr>
+    <hr>
+    <tr>
+      {{ talk.seminar.show_comments() | safe }}
     </tr>
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -119,8 +119,13 @@
     </tr>
     {% if talk.seminar.comments %}
     <tr>
+      <td colspan="2">{{ KNOWL("comments","Seminar comments") }}</td>
+    </tr>
+    <tr>
       <td colspan="2">{{ talk.seminar.show_comments() | safe }}<td>
     </tr>
+    {% else %}
+      <td colspan="2" class="forminfo">No seminar comments set</td>    
     {% endif %}
   </table>
   <hr style="width:800px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -117,13 +117,12 @@
     <tr>
       <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; any seminar comments shown below will appear in additiona to the comments you put here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
-  </table>
     {% if talk.seminar.comments %}
-    <hr style="width:800px;">
-    <p>
-      {{ seminar.show_comments() | safe }}
-    </p>
+    <tr>
+      <td colspan="2">{{ talk.seminar.show_comments() | safe }}<td>
+    </tr>
     {% endif %}
+  </table>
   <hr style="width:800px;">
   <table>
     <tr>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -117,13 +117,13 @@
     <tr>
       <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; any seminar comments shown below will appear in additiona to the comments you put here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
-    {% if talk.seminar.comments %}
-    <hr>
-    <tr>
-      <td colspan="2">{{ talk.seminar.show_comments() | safe }}<td>
-    </tr>
-    {% endif %}
   </table>
+    {% if talk.seminar.comments %}
+    <hr style="width:800px;">
+    <p>
+      {{ seminar.show_comments() | safe }}
+    </p>
+    {% endif %}
   <hr style="width:800px;">
   <table>
     <tr>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -75,7 +75,7 @@
     <tr>
       <td>{{ KNOWL("live_link") }}</td>
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
-          <td class="forminfo" />Enter "see comments" if the link is not fixed and put access instructions in comments.</td>
+          <td class="forminfo" />Enter "see comments" if the link is not fixed and put access instructions in the comments.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("access") }}</td>
@@ -118,11 +118,10 @@
       <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Put talk specific comments here such as livestream access instructions specific to this talk or notes about the speaker; any seminar comments shown below will appear in additiona to the comments you put here.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
     {% if talk.seminar.comments %}
-    <tr>
-      <td colspan="2" style="width:770px;">{{ talk.seminar.show_comments() | safe }}<td>
-    </tr>
+      <tr><td colspan="2" class="forminfo">No seminar comments set</td></tr>
+      <tr><td colspan="2" style="width:770px;">{{ talk.seminar.show_comments() | safe }}<td></tr>
     {% else %}
-      <td colspan="2" class="forminfo">No seminar comments set</td>    
+      <tr><td colspan="2" class="forminfo">No seminar comments set</td></tr
     {% endif %}
   </table>
   <hr style="width:800px;">

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -322,15 +322,13 @@ class WebSeminar(object):
         for rec in self.organizer_data:
             show = rec["curator"] if curators else not rec["curator"]
             if show and rec["display"]:
-                link = (
-                    rec["homepage"]
-                    if rec["homepage"]
-                    else ("mailto:%s" % (rec["email"]) if rec["email"] else "")
-                )
+                link = (rec["homepage"] if rec["homepage"] else ("mailto:%s" % (rec["email"]) if rec["email"] else ""))
                 name = rec["full_name"] if rec["full_name"] else link
                 if name:
-                    editors.append('<a href="%s">%s</a>' % (link, name) if link else name)
-
+                    namelink = '<a href="%s">%s</a>' % (link, name) if link else name
+                    if link and db.users.count({"email":rec["email"], "email_confimed":True}):
+                        namelink += "*"
+                    editors.append(namelink)
         if editors:
             return "<tr><td>%s:</td><td>%s</td></tr>" % (label, ", ".join(editors))
         else:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -326,7 +326,7 @@ class WebSeminar(object):
                 name = rec["full_name"] if rec["full_name"] else link
                 if name:
                     namelink = '<a href="%s">%s</a>' % (link, name) if link else name
-                    if link and db.users.count({"email":rec["email"], "email_confimed":True}):
+                    if link and db.users.count({"email":rec["email"], "email_confirmed":True}):
                         namelink += "*"
                     editors.append(namelink)
         if editors:

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -45,7 +45,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 <table>
   {{ seminar.show_organizers() | safe }}
   {{ seminar.show_curators() | safe }}
-  <td></td><td class="forminfo">*contact for this listing</td>
+  <td></td><td class="forminfo">*indicates a contact for this listing</td>
 </table>
 
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -45,7 +45,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 <table>
   {{ seminar.show_organizers() | safe }}
   {{ seminar.show_curators() | safe }}
-  <td></td><td class="forminfo">*contact</td>
+  <td></td><td class="forminfo">*contact for this listing</td>
 </table>
 
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -45,6 +45,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 <table>
   {{ seminar.show_organizers() | safe }}
   {{ seminar.show_curators() | safe }}
+  <td></td><td class="forminfo">*contact</td>
 </table>
 
 

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -30,7 +30,14 @@ from io import BytesIO
 
 from seminars import db
 
-from seminars.utils import timezones, timestamp
+from seminars.utils import (
+    timezones,
+    timestamp,
+    validate_url,
+    format_errmsg,
+    show_input_errors,
+)
+
 from seminars.tokens import generate_timed_token, read_timed_token, read_token
 import datetime
 
@@ -173,6 +180,9 @@ def info():
 @login_page.route("/set_info", methods=["POST"])
 @login_required
 def set_info():
+    homepage = request.form.get_item("homepage")
+    if homepage and not validate_url(homepage):
+        return show_input_errors([format_errmsg("Homepage %s is not a valid URL, it should begin with http:// or https://", homepage)])
     for k, v in request.form.items():
         setattr(current_user, k, v)
     previous_email = current_user.email

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -180,7 +180,7 @@ def info():
 @login_page.route("/set_info", methods=["POST"])
 @login_required
 def set_info():
-    homepage = request.form.get_item("homepage")
+    homepage = request.form.get("homepage")
     if homepage and not validate_url(homepage):
         return show_input_errors([format_errmsg("Homepage %s is not a valid URL, it should begin with http:// or https://", homepage)])
     for k, v in request.form.items():

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -135,7 +135,6 @@
       <tr>
         <td>Homepage</td>
         <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>{% if not user.homepage %} <td class=forminfo> Set this to ensure your email is hidden.</td> {% endif %}
-        <td id="urltest" /></td>
       </tr>
     <tr>
       <td>Timezone</td>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -134,7 +134,7 @@
       </tr>
       <tr>
         <td>Homepage</td>
-        <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>
+        <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>{% if not user.homepage %} <td class=forminfo> Set this to ensure your email is hidden.</td> {% endif %}
         <td id="urltest" /></td>
       </tr>
     <tr>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -135,7 +135,7 @@
       <tr>
         <td>Homepage</td>
         <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" placeholder="https://upan.edu/~someone"/></td>
-        {% if not user.homepage %} <td class=forminfo> Entering your homepage ensures your email is never visible; start .</td> {% endif %}
+        {% if not user.homepage %} <td class=forminfo> Entering your homepage ensures your email is never visible (use https if possible).</td> {% endif %}
       </tr>
     <tr>
       <td>Timezone</td>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -134,8 +134,8 @@
       </tr>
       <tr>
         <td>Homepage</td>
-        <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>
-        {% if not user.homepage %} <td class=forminfo> Entering your homepage ensures your email is never displayed.</td> {% endif %}
+        <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" placeholder="https://upan.edu/~someone"/></td>
+        {% if not user.homepage %} <td class=forminfo> Entering your homepage ensures your email is never visible; start .</td> {% endif %}
       </tr>
     <tr>
       <td>Timezone</td>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -134,7 +134,8 @@
       </tr>
       <tr>
         <td>Homepage</td>
-        <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>{% if not user.homepage %} <td class=forminfo> Set this to ensure your email is hidden.</td> {% endif %}
+        <td><input name="homepage" id="url" value="{{user.homepage}}" size="30" tabindex="3" /></td>
+        {% if not user.homepage %} <td class=forminfo> Entering your homepage ensures your email is never displayed.</td> {% endif %}
       </tr>
     <tr>
       <td>Timezone</td>


### PR DESCRIPTION
This PR ensures that whenever a seminar/conference is created or updated that there is at least one displayed organizer (or curator) with a confirmed email address.

Also ensures that names of organizers with confirmed email addresses listed have names that match their user account -- this may raise issues with existing seminars (I will run a search for this).  Warns if homepages of organizers with confirmed email addresses do not match.

Identifies organizers (or curators) with confirmed email addresses on view seminar page with an asterisk and a forminfo note "*contact for this listing".

Also add URL validation on homepage when creating/updating a user account and will display a forminfo warning that the user should enter their homepage to ensure their email address is concealed whenever this field is blank.

There are many user accounts with invalid URLs at the moment (mostly because http:// or https:// is missing).  I will run a scan and manually correct as many of these as I can.

We should test this and merge it to live as soon as we feel comfortable doing so in order to prevent more invalid user homepage URLs and seminars with no confirmed contacts listed.  But we should be aware that some seminars will not be able to be updated without making changes if they currently list no confirmed email address for any organizer, so this will impact our users.
