### PR TITLE
Update reqs since lmfdb has been hacked; reflect no sage deps

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -1,23 +1,21 @@
 Installation
 ============
 
-The `seminars` codebase is based on the [LMFDB](https://github.com/LMFDB/lmfdb) and includes it as a submodule, so the installation is similar to that project.  In particular, take the following steps to get a copy up and running locally on your machine.  After creating an account on [Github](https://github.com/join) and [uploading ssh keys](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account) there, do the following on your machine.  You need to have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [postgresql](https://www.postgresql.org/download/) and [sage](http://www.sagemath.org/download-source.html) installed.  Note that the copy of sage should be at least version 8.6, must be built with [openssl support](http://doc.sagemath.org/html/en/installation/source.html#libraries) and must currently be installed from source, though there is [work](https://trac.sagemath.org/ticket/29158) on removing that requirement).  Note that you can skip that `sage i-` and `sage -pip` commands below if you already have LMFDB functional on your machine.
+The `seminars` codebase is based on the [LMFDB](https://github.com/LMFDB/lmfdb) and includes it as a submodule, so the installation is similar to that project.  In particular, take the following steps to get a copy up and running locally on your machine.  After creating an account on [Github](https://github.com/join) and [uploading ssh keys](https://help.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account) there, do the following on your machine.  You need to have [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [postgresql](https://www.postgresql.org/download/) installed.
 
 ```
 $ git clone git@github.com:roed314/seminars.git
 $ cd seminars
 $ git submodule init
 $ git submodule update
-$ cd lmfdb
-$ sage -i gap_packages
-$ sage -pip install -r requirements
+$ pip install -r requirements.txt
 ```
 
 You can host a local version of the site by running the following in the top
 level seminars folder --- though this may raise an error at first.
 
 ```
-$ sage -python start-seminars.py --debug
+$ python start-seminars.py --debug
 ```
 
 Doing this will create the file `seminars/lmfdb/config.ini`. If you want to
@@ -44,5 +42,5 @@ After this, you can start a webserver locally by running the following in the
 top level seminars folder and no errors should be raised.
 
 ```
-$ sage -python start-seminars.py --debug
+$ python start-seminars.py --debug
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ Flask-Mail
 itsdangerous
 icalendar
 iso639
+PyYAML
+flask-login
+bcrypt
+psycopg2-binary


### PR DESCRIPTION
Since jamiesully hacked lmfdb to remove sage deps, it does not need to
be properly installed.  Therefore move the real deps up into
requirements.txt.

Reflect the fact that there is no more sage dependency in
GettingStarted.md.