### PR TITLE
restoring seminars/templates/debug_info.html

### DIFF
--- a/seminars/templates/debug_info.html
+++ b/seminars/templates/debug_info.html
@@ -1,1 +1,7 @@
-../../lmfdb/lmfdb/templates/debug_info.html
+{% if DEBUG %}
+<hr>
+<div>
+  Query was: {{info.query}}
+</div>
+Start = {{info.start}}, Count = {{info.count}}
+{% endif %}


### PR DESCRIPTION
seminars/templates/debug_info.html was a symlink to lmfdb's file,
which got deleted when jamiesully hacked it to remove sage deps.
Adding back the original source.