### PR TITLE
Allow "See comments" and "see comments" in live link

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -16,6 +16,7 @@ from seminars.utils import (
     adapt_datetime,
     sanity_check_times,
     format_errmsg,
+    format_input_errmsg,
     format_warning,
     show_input_errors,
 )
@@ -369,18 +370,14 @@ def save_seminar():
             data[col] = None  # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
+            errmsgs.append(format_input_errmsg(err, val, col))
     if not data["name"]:
         errmsgs.append("Seminar name cannot be blank")
     if seminar.is_conference and data["start_date"] and data["end_date"] and data["end_date"] < data["start_date"]:
         errmsgs.append("End date cannot precede start date")
     for col in ["frequency", "per_day"]:
         if data[col] is not None and data[col] < 1:
-            errmsgs.append(
-                format_errmsg(
-                    'Unable to process input "%s" for property %s: a positive integer is required', raw_data.get(col, ""), col,
-                )
-            )
+            errmsgs.append(errmsgs.append(format_input_errmsg("integer must be positive", val, col)))
     data["institutions"] = clean_institutions(data.get("institutions"))
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))
@@ -401,10 +398,10 @@ def save_seminar():
                 D[col] = None  # make sure col is present even if process_user_input fails
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:  # should only be ValueError's but let's be cautious
-                errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
+                errmsgs.append(format_input_errmsg(err, val, col))
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
-                errmsgs.append(format_errmsg("organizer %s cannot be blank", "name"))
+                errmsgs.append(format_errmsg("Organizer name cannot be left blank"))
             D["order"] = len(organizer_data)
             # WARNING the header on the template says organizer
             # but it sets the database column curator, so the
@@ -530,10 +527,10 @@ def save_institution():
                         errmsgs.append("You must specify the email address of the maintainer.")
                         continue
                     else:
-                        errmsgs.append(format_errmsg("user %s does not have an account on this site", data[col]))
+                        errmsgs.append(format_errmsg("User %s does not have an account on this site", data[col]))
                         continue
                 elif not userdata["creator"]:
-                    errmsgs.append(format_errmsg("user %s has not been endorsed", data[col]))
+                    errmsgs.append(format_errmsg("User %s has not been endorsed", data[col]))
                     continue
                 if not userdata["homepage"]:
                     if current_user.email == userdata["email"]:
@@ -553,7 +550,7 @@ def save_institution():
                             "error",
                         )
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
+            errmsgs.append(format_input_errmsg(err, val, col))
     if not data["name"]:
         errmsgs.append("Institution name cannot be blank.")
     if not errmsgs and not data["homepage"]:
@@ -661,9 +658,9 @@ def save_talk():
             data[col] = None  # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
             if col == "access" and data[col] not in ["open", "users", "endorsed"]:
-                errmsgs.append(format_errmsg("access type %s invalid", data[col]))
+                errmsgs.append(format_errmsg("Access type %s invalid", data[col]))
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
+            errmsgs.append(format_input_errmsg(err, val, col))
     if not data["speaker"]:
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:
@@ -882,7 +879,7 @@ def save_seminar_schedule():
             try:
                 date = process_user_input(date, "date", "date", tz)
             except Exception as err:  # should only be ValueError's but let's be cautious
-                errmsgs.append(format_errmsg('Unable to process date input "%s": {0}'.format(err), date))
+                errmsgs.append(format_input_errmsg(err, date, "date"))
         else:
             errmsgs.append(format_errmsg("You must specify a date for the talk by %s", speaker))
         time_input = raw_data.get("time%s" % i, "").strip()
@@ -900,7 +897,7 @@ def save_seminar_schedule():
                 start_time = process_user_input(time_split[0], "start_time", "time", tz)
                 end_time = process_user_input(time_split[1], "end_time", "time", tz)
             except Exception as err:
-                errmsgs.append(format_errmsg('Unable to process time input "%s": {0}'.format(err), time_input,))
+                errmsgs.append(format_input_errmsg(err, time_input, "time"))
         if any(X is None for X in [start_time, end_time]):
             errmsgs.append(format_errmsg("You must specify a start and end time for the talk by speaker %s", speaker))
         else:
@@ -941,7 +938,7 @@ def save_seminar_schedule():
                 data[col] = None  # make sure col is present even if process_user_input fails
                 data[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
-                errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
+                errmsgs.append(format_input_errmsg(err, val, col))
 
         # Don't try to create new_version using invalid input
         if errmsgs:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -369,7 +369,7 @@ def save_seminar():
             data[col] = None  # make sure col is present even if process_user_input fails
             data[col] = process_user_input(val, col, typ, tz)
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
+            errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
     if not data["name"]:
         errmsgs.append("Seminar name cannot be blank")
     if seminar.is_conference and data["start_date"] and data["end_date"] and data["end_date"] < data["start_date"]:
@@ -378,7 +378,7 @@ def save_seminar():
         if data[col] is not None and data[col] < 1:
             errmsgs.append(
                 format_errmsg(
-                    "Unable to process input %s for %s: a positive integer is required", raw_data.get(col, ""), col,
+                    'Unable to process input "%s" for property %s: a positive integer is required', raw_data.get(col, ""), col,
                 )
             )
     data["institutions"] = clean_institutions(data.get("institutions"))
@@ -401,7 +401,7 @@ def save_seminar():
                 D[col] = None  # make sure col is present even if process_user_input fails
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:  # should only be ValueError's but let's be cautious
-                errmsgs.append(format_errmsg('unable to process input "%s" for property %s: {0}'.format(err), val, col))
+                errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
                 errmsgs.append(format_errmsg("organizer %s cannot be blank", "name"))
@@ -553,7 +553,7 @@ def save_institution():
                             "error",
                         )
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg('unable to process input "%s" for property %s: {0}'.format(err), val, col))
+            errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
     if not data["name"]:
         errmsgs.append("Institution name cannot be blank.")
     if not errmsgs and not data["homepage"]:
@@ -663,7 +663,7 @@ def save_talk():
             if col == "access" and data[col] not in ["open", "users", "endorsed"]:
                 errmsgs.append(format_errmsg("access type %s invalid", data[col]))
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg('unable to process input "%s" for property %s: {0}'.format(err), val, col))
+            errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
     if not data["speaker"]:
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:
@@ -941,7 +941,7 @@ def save_seminar_schedule():
                 data[col] = None  # make sure col is present even if process_user_input fails
                 data[col] = process_user_input(val, col, typ, tz)
             except Exception as err:
-                errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
+                errmsgs.append(format_errmsg('Unable to process input "%s" for property %s: {0}'.format(err), val, col))
 
         # Don't try to create new_version using invalid input
         if errmsgs:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -401,7 +401,7 @@ def save_seminar():
                 D[col] = None  # make sure col is present even if process_user_input fails
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:  # should only be ValueError's but let's be cautious
-                errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
+                errmsgs.append(format_errmsg('unable to process input "%s" for property %s: {0}'.format(err), val, col))
         if D["homepage"] or D["email"] or D["full_name"]:
             if not D["full_name"]:
                 errmsgs.append(format_errmsg("organizer %s cannot be blank", "name"))
@@ -553,7 +553,7 @@ def save_institution():
                             "error",
                         )
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg("unable to process input %s for %s: {0}".format(err), val, col))
+            errmsgs.append(format_errmsg('unable to process input "%s" for property %s: {0}'.format(err), val, col))
     if not data["name"]:
         errmsgs.append("Institution name cannot be blank.")
     if not errmsgs and not data["homepage"]:
@@ -663,7 +663,7 @@ def save_talk():
             if col == "access" and data[col] not in ["open", "users", "endorsed"]:
                 errmsgs.append(format_errmsg("access type %s invalid", data[col]))
         except Exception as err:  # should only be ValueError's but let's be cautious
-            errmsgs.append(format_errmsg("Unable to process input %s for %s: {0}".format(err), val, col))
+            errmsgs.append(format_errmsg('unable to process input "%s" for property %s: {0}'.format(err), val, col))
     if not data["speaker"]:
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:
@@ -882,7 +882,7 @@ def save_seminar_schedule():
             try:
                 date = process_user_input(date, "date", "date", tz)
             except Exception as err:  # should only be ValueError's but let's be cautious
-                errmsgs.append(format_errmsg("Unable to process input %s for date: {0}".format(err), date))
+                errmsgs.append(format_errmsg('Unable to process date input "%s": {0}'.format(err), date))
         else:
             errmsgs.append(format_errmsg("You must specify a date for the talk by %s", speaker))
         time_input = raw_data.get("time%s" % i, "").strip()
@@ -900,7 +900,7 @@ def save_seminar_schedule():
                 start_time = process_user_input(time_split[0], "start_time", "time", tz)
                 end_time = process_user_input(time_split[1], "end_time", "time", tz)
             except Exception as err:
-                errmsgs.append(format_errmsg("Unable to process input %s for time: {0}".format(err), time_input,))
+                errmsgs.append(format_errmsg('Unable to process time input "%s": {0}'.format(err), time_input,))
         if any(X is None for X in [start_time, end_time]):
             errmsgs.append(format_errmsg("You must specify a start and end time for the talk by speaker %s", speaker))
         else:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -377,7 +377,7 @@ def save_seminar():
         errmsgs.append("End date cannot precede start date")
     for col in ["frequency", "per_day"]:
         if data[col] is not None and data[col] < 1:
-            errmsgs.append(errmsgs.append(format_input_errmsg("integer must be positive", val, col)))
+            errmsgs.append(format_input_errmsg("integer must be positive", data[col], col))
     data["institutions"] = clean_institutions(data.get("institutions"))
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -1,7 +1,7 @@
 from seminars.app import app
 from seminars import db
 from seminars.talk import talks_search, talks_lucky
-from seminars.utils import topics, user_topics, toggle, Toggle, languages_dict
+from seminars.utils import user_topics, toggle, Toggle, languages_dict
 from seminars.institution import institutions, WebInstitution
 from seminars.knowls import static_knowl
 from flask import render_template, request, redirect, url_for, Response, make_response

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -370,7 +370,7 @@ def process_user_input(inp, col, typ, tz):
         t = t.replace(year=2020, month=1, day=1)
         return localize_time(t, tz)
     elif (col.endswith("page") or col.endswith("link")) and typ == "text":
-        if not validate_url(inp) and not (col == "live_link" and inp == "see comments"):
+        if not validate_url(inp) and not (col == "live_link" and (inp == "see comments" or inp == "See comments")):
             raise ValueError("Invalid URL")
         return inp
     elif col.endswith("email") and typ == "text":

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -411,7 +411,7 @@ def format_errmsg(errmsg, *args):
     return Markup("Error: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)))
 
 def format_input_errmsg(err, inp, col):
-    return format_errmsg('Unable to process input %s for property %s: {0}'.format(err), '"' + inp + '"', col)
+    return format_errmsg('Unable to process input %s for property %s: {0}'.format(err), '"' + str(inp) + '"', col)
 
 def format_warning(errmsg, *args):
     return Markup("Warning: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)))

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -410,6 +410,8 @@ def process_user_input(inp, col, typ, tz):
 def format_errmsg(errmsg, *args):
     return Markup("Error: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)))
 
+def format_input_errmsg(err, inp, col):
+    return format_errmsg('Unable to process input %s for property %s: {0}'.format(err), '"' + inp + '"', col)
 
 def format_warning(errmsg, *args):
     return Markup("Warning: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)))


### PR DESCRIPTION
The instructions for live link were inconsistent with the input validation, now it allows the user to enter either "see comments" or "See comments".

Also uniformizes user input errors and quotes the input the user typed in the error message to make it clearer exactly where the problem is.