### PR TITLE
Strip leading/trailing spaces when updating user info

### DIFF
--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -184,7 +184,7 @@ def set_info():
     if homepage and not validate_url(homepage):
         return show_input_errors([format_errmsg("Homepage %s is not a valid URL, it should begin with http:// or https://", homepage)])
     for k, v in request.form.items():
-        setattr(current_user, k, v)
+        setattr(current_user, k, v.strip())
     previous_email = current_user.email
     if current_user.save():
         flask.flash(Markup("Thank you for updating your details!"))


### PR DESCRIPTION
Fix to avoid a very confusing problem caused by user whose name had a trailing space in it that was preventing the user from saving their seminar because the names did not match.
