### PR TITLE
Clarify video recording link

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -669,7 +669,7 @@ def save_talk():
     if errmsgs:
         return show_input_errors(errmsgs)
     if "zoom" in data["video_link"] and not "rec" in data["video_link"]:
-        flash_warning("Recorded video link should not be used for Zoom meeting links, use Livestream link above.")
+        flash_warning("Recorded video link should not be used for Zoom meeting links; be sure to use Livestream link for meeting links.\n")
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))
     new_version = WebTalk(talk.seminar_id, data["seminar_ctr"], data=data)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -668,6 +668,8 @@ def save_talk():
     # Don't try to create new_version using invalid input
     if errmsgs:
         return show_input_errors(errmsgs)
+    if "zoom" in data["video_link"] and not "rec" in data["video_link"]:
+        flash_warning("Recorded video link should not be used for Zoom meeting links, use Livestream link above.")
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))
     new_version = WebTalk(talk.seminar_id, data["seminar_ctr"], data=data)

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -77,7 +77,7 @@
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
     </tr>
     <tr>
-      <td>{{ KNOWL("access") }}</td><td class="forminfo">This controls who can see the livestream link.</td>
+      <td>{{ KNOWL("access") }}</td>
       <td>
         <select name="access" style="width:610px;">
           <option value="open"{% if talk.access == 'open' %} selected{% endif %}>All visitors can view link</option>
@@ -85,6 +85,7 @@
           <option value="endorsed"{% if talk.access == 'endorsed' %} selected{% endif %}>Only endorsed users can view link</option>
         </select>
       </td>
+      <td class="forminfo">This controls who can see the livestream link.</td>
     </tr>
     {% else %}
     <tr>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -75,10 +75,9 @@
     <tr>
       <td>{{ KNOWL("live_link") }}</td>
       <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
-          <td class="forminfo" />If link varies, enter "See comments" and leave instructions below in Comments.</td>
     </tr>
     <tr>
-      <td>{{ KNOWL("access") }}</td>
+      <td>{{ KNOWL("access") }}</td><td class="forminfo">This controls who can see the livestream link.</td>
       <td>
         <select name="access" style="width:610px;">
           <option value="open"{% if talk.access == 'open' %} selected{% endif %}>All visitors can view link</option>

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -285,7 +285,7 @@ slide_link:
     A URL link to a slide presentation used in the talk.  
     This may be set either before or after the talk.
 video_link:
-  title: Video link
+  title: Recorded video link
   contents: |
     A URL link to a video recording of the talk.
 talk_date:


### PR DESCRIPTION
Warns user if it looks like they are pasting a Zoom meeting link into the video recording link.
