### PR TITLE
Add ics for single talks and single seminar series

### DIFF
--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -656,8 +656,26 @@ def ics_seminar_file(shortname):
     bIO = BytesIO()
     bIO.write(cal.to_ical())
     bIO.seek(0)
-    return send_file(bIO, attachment_filename="seminars.ics", as_attachment=True, add_etags=False)
+    return send_file(bIO, attachment_filename="{}.ics".format(shortname), as_attachment=True, add_etags=False)
 
+
+@app.route("/talk/<semid>/<int:talkid>/ics")
+def ics_talk_file(semid, talkid):
+    talk = talks_lucky({"seminar_id": semid, "seminar_ctr": talkid})
+    if talk is None:
+        return render_template("404.html", title="Talk not found")
+
+    cal = Calendar()
+    cal.add("VERSION", "2.0")
+    cal.add("PRODID", topdomain())
+    cal.add("CALSCALE", "GREGORIAN")
+    cal.add("X-WR-CALNAME", topdomain())
+
+    cal.add_component(talk.event(user=current_user))
+    bIO = BytesIO()
+    bIO.write(cal.to_ical())
+    bIO.seek(0)
+    return send_file(bIO, attachment_filename="{}_{}.ics".format(semid, talkid), as_attachment=True, add_etags=False)
 
 @app.route("/talk/<semid>/<int:talkid>/")
 def show_talk(semid, talkid):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -13,7 +13,6 @@ from seminars.utils import (
     search_distinct,
     show_input_errors,
     toggle,
-    topdomain,
     topic_dict,
     weekdays,
 )
@@ -136,7 +135,6 @@ class WebSeminar(object):
     def save(self):
         data = {col: getattr(self, col, None) for col in db.seminars.search_cols}
         assert data.get("shortname")
-        topics = self.topics if self.topics else []
         data["edited_by"] = int(current_user.id)
         data["edited_at"] = datetime.now(tz=pytz.UTC)
         db.seminars.insert_many([data])

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -25,6 +25,8 @@ from collections import defaultdict
 from datetime import datetime
 from lmfdb.logger import critical
 
+import urllib.parse
+
 combine = datetime.combine
 
 
@@ -377,6 +379,20 @@ class WebSeminar(object):
         if self.user_can_edit():
             query.pop("display")
         return talks_search(query, projection=projection)
+
+    @property
+    def ics_link(self):
+        return url_for(".ics_seminar_file", shortname=self.shortname, _external=True, _scheme="https")
+
+    @property
+    def ics_gcal_link(self):
+        return "https://calendar.google.com/calendar/render?" + urllib.parse.urlencode(
+            {"cid": url_for(".ics_seminar_file", shortname=self.shortname, _external=True, _scheme="http")}
+        )
+
+    @property
+    def ics_webcal_link(self):
+        return url_for(".ics_seminar_file", shortname=self.shortname, _external=True, _scheme="webcal")
 
     @property
     def next_talk_time(self):

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -352,19 +352,19 @@ class WebTalk(object):
 
     @property
     def ics_link(self):
-        return url_for(".ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
+        return url_for("ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
                        _external=True, _scheme="https")
 
     @property
     def ics_gcal_link(self):
         return "https://calendar.google.com/calendar/render?" + urllib.parse.urlencode(
-            {"cid": url_for(".ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
+            {"cid": url_for("ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
                             _external=True, _scheme="http")}
         )
 
     @property
     def ics_webcal_link(self):
-        return url_for(".ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
+        return url_for("ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
                        _external=True, _scheme="webcal")
 
     def is_past(self):

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -20,6 +20,7 @@ from seminars.seminar import WebSeminar, can_edit_seminar
 from lmfdb.utils import flash_error
 from markupsafe import Markup
 from psycopg2.sql import SQL
+import urllib.parse
 from icalendar import Event
 from lmfdb.logger import critical
 
@@ -348,6 +349,23 @@ class WebTalk(object):
 
     def show_video_link(self):
         return '<a href="%s">video</a>'%(self.video_link) if self.video_link else ""
+
+    @property
+    def ics_link(self):
+        return url_for(".ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
+                       _external=True, _scheme="https")
+
+    @property
+    def ics_gcal_link(self):
+        return "https://calendar.google.com/calendar/render?" + urllib.parse.urlencode(
+            {"cid": url_for(".ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
+                            _external=True, _scheme="http")}
+        )
+
+    @property
+    def ics_webcal_link(self):
+        return url_for(".ics_talk_file", semid=self.seminar_id, talkid=self.seminar_ctr,
+                       _external=True, _scheme="webcal")
 
     def is_past(self):
         return self.end_time < datetime.datetime.now(pytz.utc)

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -14,7 +14,6 @@ from seminars.utils import (
     make_links,
     topic_dict,
     languages_dict,
-    topdomain,
 )
 from seminars.seminar import WebSeminar, can_edit_seminar
 from lmfdb.utils import flash_error
@@ -124,7 +123,6 @@ class WebTalk(object):
     def save(self):
         data = {col: getattr(self, col, None) for col in db.talks.search_cols}
         assert data.get("seminar_id") and data.get("seminar_ctr")
-        topics = self.topics if self.topics else []
         try:
             data["edited_by"] = int(current_user.id)
         except (ValueError, AttributeError):

--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -18,6 +18,30 @@ console.log('Form is unchanged!');
 }
   };
 {%- endmacro %}
+{% macro calendar_block(name, obj) -%}
+  <div>
+    Export {{name}} to
+      <ul class="ical-detail">
+        <li class="ical-detail">
+          <a href="{{ obj.ics_gcal_link }}" target="_blank">
+            <i class="fab fa-google"></i> Google Calendar
+          </a>
+        </li>
+        <li class="ical-detail">
+          <a href="{{ obj.ics_webcal_link }}" target="_blank">
+            <i class="fas fa-calendar-alt"></i> iCal/Outlook
+          </a>
+        </li>
+        <li class="ical-detail">
+          <a href="{{ obj.ics_link }}" target="_blank">
+            <i class="fas fa-file-download"></i> ICS file
+          </a>
+        </li>
+      </ul>
+      <br>
+    Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
+  </div>
+{%- endmacro %}
 
 {% block body -%}
 <div id="header">

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -106,6 +106,29 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 </div>
 {% endif %}
 
+  <div>
+      Export seminar to
+      <ul class="ical-detail">
+        <li class="ical-detail">
+          <a href="{{ seminar.ics_gcal_link }}" target="_blank">
+            <i class="fab fa-google"></i> Google Calendar
+          </a>
+        </li>
+        <li class="ical-detail">
+          <a href="{{ seminar.ics_webcal_link }}" target="_blank">
+            <i class="fas fa-calendar-alt"></i> iCal/Outlook
+          </a>
+        </li>
+        <li class="ical-detail">
+          <a href="{{ seminar.ics_link }}" target="_blank">
+            <i class="fas fa-file-download"></i> ICS file
+          </a>
+        </li>
+      </ul>
+      <br>
+    Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
+  </div>
+
 {% if past and not future %}
 <script>
 $(document).ready(function () {

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -106,28 +106,8 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 </div>
 {% endif %}
 
-  <div>
-      Export seminar to
-      <ul class="ical-detail">
-        <li class="ical-detail">
-          <a href="{{ seminar.ics_gcal_link }}" target="_blank">
-            <i class="fab fa-google"></i> Google Calendar
-          </a>
-        </li>
-        <li class="ical-detail">
-          <a href="{{ seminar.ics_webcal_link }}" target="_blank">
-            <i class="fas fa-calendar-alt"></i> iCal/Outlook
-          </a>
-        </li>
-        <li class="ical-detail">
-          <a href="{{ seminar.ics_link }}" target="_blank">
-            <i class="fas fa-file-download"></i> ICS file
-          </a>
-        </li>
-      </ul>
-      <br>
-    Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
-  </div>
+{{ calendar_block('seminar', seminar) }}
+
 
 {% if past and not future %}
 <script>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -46,6 +46,29 @@
   {{talk.seminar.show_comments() | safe}}
   {% endif %}
 
+<div>
+  Export talk to
+  <ul class="ical-detail">
+    <li class="ical-detail">
+      <a href="{{ talk.ics_gcal_link }}" target="_blank">
+        <i class="fab fa-google"></i> Google Calendar
+      </a>
+    </li>
+    <li class="ical-detail">
+      <a href="{{ talk.ics_webcal_link }}" target="_blank">
+        <i class="fas fa-calendar-alt"></i> iCal/Outlook
+      </a>
+    </li>
+    <li class="ical-detail">
+      <a href="{{ talk.ics_link }}" target="_blank">
+        <i class="fas fa-file-download"></i> ICS file
+      </a>
+    </li>
+  </ul>
+  <br>
+  Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
+</div>
+
    <div align="right">
         <p>
     <b>{{ talk.show_time_and_duration() | safe }}</b>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -78,5 +78,27 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   {% endif %}
 </div>
 
+  <div>
+    Export talk to
+    <ul class="ical-detail">
+      <li class="ical-detail">
+        <a href="{{ talk.ics_gcal_link }}" target="_blank">
+          <i class="fab fa-google"></i> Google Calendar
+        </a>
+      </li>
+      <li class="ical-detail">
+        <a href="{{ talk.ics_webcal_link }}" target="_blank">
+          <i class="fas fa-calendar-alt"></i> iCal/Outlook
+        </a>
+      </li>
+      <li class="ical-detail">
+        <a href="{{ talk.ics_link }}" target="_blank">
+          <i class="fas fa-file-download"></i> ICS file
+        </a>
+      </li>
+    </ul>
+    <br>
+    Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
+  </div>
 
 {% endblock %}

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -78,27 +78,6 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   {% endif %}
 </div>
 
-  <div>
-    Export talk to
-    <ul class="ical-detail">
-      <li class="ical-detail">
-        <a href="{{ talk.ics_gcal_link }}" target="_blank">
-          <i class="fab fa-google"></i> Google Calendar
-        </a>
-      </li>
-      <li class="ical-detail">
-        <a href="{{ talk.ics_webcal_link }}" target="_blank">
-          <i class="fas fa-calendar-alt"></i> iCal/Outlook
-        </a>
-      </li>
-      <li class="ical-detail">
-        <a href="{{ talk.ics_link }}" target="_blank">
-          <i class="fas fa-file-download"></i> ICS file
-        </a>
-      </li>
-    </ul>
-    <br>
-    Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
-  </div>
+{{ calendar_block('talk', talk) }}
 
 {% endblock %}

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -14,7 +14,6 @@ from flask import (
     redirect,
     make_response,
     session,
-    send_file,
 )
 from flask_login import (
     login_required,
@@ -25,18 +24,17 @@ from flask_login import (
 )
 from lmfdb.utils import flash_error
 from markupsafe import Markup
-from icalendar import Calendar
-from io import BytesIO
 
 from seminars import db
 
 from seminars.utils import (
-    timezones,
-    timestamp,
-    validate_url,
     format_errmsg,
+    ics_file,
     show_input_errors,
+    timestamp,
+    timezones,
     topdomain,
+    validate_url,
 )
 
 from seminars.tokens import generate_timed_token, read_timed_token, read_token
@@ -566,7 +564,7 @@ def talk_subscriptions_remove(shortname, ctr):
 
 
 @login_page.route("/ics/<token>")
-def ics_file(token):
+def user_ics_file(token):
     try:
         uid = read_token(token, "ics")
         user = SeminarsUser(uid=int(uid))
@@ -575,27 +573,18 @@ def ics_file(token):
     except Exception:
         return flask.abort(404, "Invalid link")
 
-    cal = Calendar()
-    cal.add("VERSION", "2.0")
-    cal.add("PRODID", topdomain())
-    cal.add("CALSCALE", "GREGORIAN")
-    cal.add("X-WR-CALNAME", topdomain())
-
-    for talk in user.talks:
-        # Organizers may have hidden talk
-        if talk.hidden or talk.seminar.visibility == 0:
-            continue
-        cal.add_component(talk.event(user))
+    talks = [t for t in user.talks if not (t.hidden or t.seminar.visibility == 0)]
     for seminar in user.seminars:
         # Organizers may have hidden seminar
         if seminar.visibility == 0:
             continue
         for talk in seminar.talks():
-            cal.add_component(talk.event(user))
-    bIO = BytesIO()
-    bIO.write(cal.to_ical())
-    bIO.seek(0)
-    return send_file(bIO, attachment_filename="seminars.ics", as_attachment=True, add_etags=False)
+            talks.append(talk)
+    return ics_file(
+        talks=talks,
+        filename="semianars.ics",
+        user=user)
+
 
 
 @login_page.route("/public/")

--- a/seminars/users/pwdmanager.py
+++ b/seminars/users/pwdmanager.py
@@ -343,17 +343,17 @@ class SeminarsUser(UserMixin):
 
     @property
     def ics_link(self):
-        return url_for(".ics_file", token=self.ics, _external=True, _scheme="https")
+        return url_for(".user_ics_file", token=self.ics, _external=True, _scheme="https")
 
     @property
     def ics_gcal_link(self):
         return "https://calendar.google.com/calendar/render?" + urllib.parse.urlencode(
-            {"cid": url_for(".ics_file", token=self.ics, _external=True, _scheme="http")}
+            {"cid": url_for(".user_ics_file", token=self.ics, _external=True, _scheme="http")}
         )
 
     @property
     def ics_webcal_link(self):
-        return url_for(".ics_file", token=self.ics, _external=True, _scheme="webcal")
+        return url_for(".user_ics_file", token=self.ics, _external=True, _scheme="webcal")
 
     @property
     def seminar_subscriptions(self):

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -58,28 +58,7 @@
     Please confirm your email to get access to your personalized calendar.
   </p>
   {% else %}
-  <div>
-      Export favorites to
-      <ul class="ical-detail">
-        <li class="ical-detail">
-          <a href="{{ user.ics_gcal_link }}" target="_blank">
-            <i class="fab fa-google"></i> Google Calendar
-          </a>
-        </li>
-        <li class="ical-detail">
-          <a href="{{ user.ics_webcal_link }}" target="_blank">
-            <i class="fas fa-calendar-alt"></i> iCal/Outlook
-          </a>
-        </li>
-        <li class="ical-detail">
-          <a href="{{ user.ics_link }}" target="_blank">
-            <i class="fas fa-file-download"></i> ICS file
-          </a>
-        </li>
-      </ul>
-      <br>
-    Some calendar services sync external calendars only every <a href="https://kb.mit.edu/confluence/display/istcontrib/How+to+change+the+update+frequency+of+a+calendar+I+am+subscribing+to">~24 hours</a>.
-  </div>
+    {{ calendar_block('favorites', user) }}
   {% endif %}
 
   {% if user.is_creator %}


### PR DESCRIPTION
Addresses #338. The gcal/ical/ics links for individual talks now appear in the talk's knowl, and on the talk's detail page. The gcal/ical/ics link appear on the seminar's page. There is a bit of repetition in the templates that could be reduced if class names that appear inside templates can themselves be templated. Is that possible?