### PR TITLE
External talk knowl bugfix for bug reported by @tornaria

### DIFF
--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -603,7 +603,8 @@ def show_seminar_bare(shortname):
     talks = talks_search_api(shortname)
     resp = make_response(render_template("seminar_bare.html",
                                          title=seminar.name, talks=talks,
-                                         seminar=seminar))
+                                         seminar=seminar,
+                                         _external=( '_external' in request.args )))
     resp.headers['Access-Control-Allow-Origin'] = '*'
     return resp
 

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -260,10 +260,10 @@ class WebTalk(object):
             title=self.show_title(),
         )
 
-    def show_knowl_title(self):
+    def show_knowl_title(self, _external=False):
         return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
             title=self.show_title(),
-            content=Markup.escape(render_template("talk-knowl.html", talk=self)),
+            content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external)),
         )
 
     def show_lang_topics(self):
@@ -435,14 +435,14 @@ class WebTalk(object):
             tglid="tlg" + value, value=value, checked=self.is_subscribed(), classes="subscribe"
         )
 
-    def oneline(self, include_seminar=True, include_subscribe=True, tz=None):
+    def oneline(self, include_seminar=True, include_subscribe=True, tz=None, _external=False):
         cols = []
         cols.append(('class="date"', self.show_date(tz=tz)))
         cols.append(('class="time"', self.show_start_time(tz=tz)))
         if include_seminar:
             cols.append(('class="seminar"', self.show_seminar()))
         cols.append(('class="speaker"', self.show_speaker(affiliation=False)))
-        cols.append(('class="talktitle"', self.show_knowl_title()))
+        cols.append(('class="talktitle"', self.show_knowl_title(_external=_external)))
         if include_subscribe:
             cols.append(('class="subscribe"', self.show_subscribe()))
         #cols.append(('style="display: none;"', self.show_link_title()))

--- a/seminars/templates/embed_seminars.js
+++ b/seminars/templates/embed_seminars.js
@@ -57,6 +57,8 @@
       }
     }
 
+    fetchURL += "&_external="
+
     var xhr = new XMLHttpRequest();
     xhr.responseType = "document";
 

--- a/seminars/templates/seminar_bare.html
+++ b/seminars/templates/seminar_bare.html
@@ -6,7 +6,7 @@
     </thead>
     {% for talk in talks %}
     <tr>
-      {{ talk.oneline(include_seminar=False, include_subscribe=False, tz=seminar.tz) | safe }}
+      {{ talk.oneline(include_seminar=False, include_subscribe=False, tz=seminar.tz, _external=_external) | safe }}
     </tr>
     {% endfor %}
   </table>

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -5,7 +5,7 @@
         <h3> <i>{{ talk.show_speaker() | safe }}</i></h3>
       </div>
       <div class="talk-view">
-        ( <a href="{{url_for('show_talk', semid=talk.seminar_id, talkid=talk.seminar_ctr)}}">view</a> {% if talk.user_can_edit() %} | <a href="{{url_for('create.edit_talk', seminar_id=talk.seminar_id, seminar_ctr=talk.seminar_ctr)}}">edit</a> {% endif %} )
+        ( <a href="{{url_for('show_talk', semid=talk.seminar_id, talkid=talk.seminar_ctr, _external=_external)}}">view</a> {% if talk.user_can_edit() %} | <a href="{{url_for('create.edit_talk', seminar_id=talk.seminar_id, seminar_ctr=talk.seminar_ctr, _external=_external)}}">edit</a> {% endif %} )
       </div>
   </div>
   <div style="clear:both;"></div>
@@ -37,7 +37,7 @@
   <hr>
 
   <p>
-    <b>{{ talk.show_seminar() | safe }} </b>
+    <b>{{ talk.show_seminar(external=_external) | safe }} </b>
   </p>
 
   {% if talk.seminar.comments %}


### PR DESCRIPTION
Add _external keyword in a bunch of places, so that talk knowl can be
generated with or without external links.