### PR TITLE
Fix duplicate talk bug in edit schedule (plus a few other things)

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -403,7 +403,7 @@ def save_seminar():
         errmsgs.append(format_input_errmsg("integer must be positive", data["per_day"], "per_day"))
     if seminar.is_conference and not (data["start_date"] and data["end_date"]):
         flash_warning ("Please enter the start and end dates of your conference if available.")
-    if not data["per_day"]:
+    if seminar.is_conference and not data["per_day"]:
         flash_warning ("It will be easier to edit the conference schedule if you specify talks per day (an upper bound is fine).")
 
     data["institutions"] = clean_institutions(data.get("institutions"))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -399,7 +399,7 @@ def save_seminar():
         errmsgs.append("The name cannot be blank")
     if seminar.is_conference and data["start_date"] and data["end_date"] and data["end_date"] < data["start_date"]:
         errmsgs.append("End date cannot precede start date")
-    if data["per_day"] is not None and data[col] < 1:
+    if data["per_day"] is not None and data["per_day"] < 1:
         errmsgs.append(format_input_errmsg("integer must be positive", data["per_day"], "per_day"))
     if seminar.is_conference and not (data["start_date"] and data["end_date"]):
         flash_warning ("Please enter the start and end dates of your conference if available.")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -236,7 +236,7 @@
         {% if seminar.user_can_delete() %}
         <a style="margin-left: 30px"  href="{{ url_for("create.delete_seminar", shortname=seminar.shortname) }}" onclick="unsaved = false;return confirm('Are you sure you want to delete this {% if seminar.is_conference %}conference{% else %}seminar{% endif %} and all of its talks?');">
           <button type="button">
-            Delete seminar
+            Delete series
           </button>
         </a>
         {% endif %}

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -21,7 +21,7 @@ import re
 
 weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 short_weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
-daytime_re_string = r'\d{1,2}|\d{1,2}:\d\d'
+daytime_re_string = r'\d{1,4}|\d{1,2}:\d\d|'
 daytime_re = re.compile(daytime_re_string)
 
 def topdomain():
@@ -42,8 +42,13 @@ def validate_daytime(s):
     s = s.strip()
     if not daytime_re.fullmatch(s):
         return None
-    t = s.split(':')
-    (h, m) = (int(t[0]), int(t[1])) if len(t) == 2 else (int(t[0]), 0)
+    if len(s) <= 2:
+        h, m = int(s), 0
+    elif not ':' in s:
+        h, m = int(s[:-2]), int(s[-2:])
+    else:
+        t = s.split(':')
+        h, m = int(t[0]), int(t[1])
     return "%02d:%02d"%(h,m) if (0 <= h < 24) and (0 <= m <= 59) else None
 
 def validate_daytimes(s):
@@ -160,14 +165,6 @@ def clean_language(inp):
         return "en"
     else:
         return inp
-
-
-def flash_warning(warnmsg, *args):
-    flash(
-        Markup("Warning: " + (warnmsg % tuple("<span style='color:red'>%s</span>" % escape(x) for x in args))),
-        "warning",
-    )
-
 
 def sanity_check_times(start_time, end_time):
     """
@@ -536,11 +533,17 @@ def process_user_input(inp, col, typ, tz):
 def format_errmsg(errmsg, *args):
     return Markup("Error: " + (errmsg % tuple("<span style='color:black'>%s</span>" % escape(x) for x in args)))
 
+
 def format_input_errmsg(err, inp, col):
     return format_errmsg('Unable to process input %s for property %s: {0}'.format(err), '"' + str(inp) + '"', col)
 
-def format_warning(errmsg, *args):
-    return Markup("Warning: " + (errmsg % tuple("<span style='color:red'>%s</span>" % escape(x) for x in args)))
+
+def format_warning(warnmsg, *args):
+    return Markup("Warning: " + (warnmsg % tuple("<span style='color:red'>%s</span>" % escape(x) for x in args)))
+
+
+def flash_warning(warnmsg, *args):
+    flash(format_warning(warnmsg, *args), "warning")
 
 
 def show_input_errors(errmsgs):


### PR DESCRIPTION
This PR fixes a bug in edit schedule that can lead to duplicate talks.  Currently on live if you edit the schedule of a series and enter two new talks the second of which has an invalid email address listed (or invalid URL or other input error) and click save, you will be taken to an error message telling you to press the back button, fix the bad email address, and try again.  But this results in the first talk (which had no errors) being created twice.

With this change all updates to the database are deferred until all validation of input errors has been completed.

I also changed the button caption "Delete seminar" to "Delete series" on the Edit series page, and uniformized some of the warning messages (they should now all be black text on a red background, as opposed to error message which are red on a red background).