### PR TITLE
Js

### DIFF
--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -151,7 +151,7 @@ const subjOptions = [
   {% endfor %}
 ];
 
-$(document).ready(function() {
+document.addEventListener("DOMContentLoaded", function() {
   makeInstitutionSelector(instOptions, []);
   makeSubjectSelector(subjOptions, []);
 });

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -243,9 +243,6 @@
       {% endif %}
       </form>
 <script type="text/javascript">
-/* prevent accidental closing of browser window */
-{{ prevent_unsaved() }}
-
 /* topic and inst selector */
 const topicOptions = [
   {% for ab, topic in user_topics(seminar) %}
@@ -284,6 +281,9 @@ const subjOptions = [
 ];
 
 $(document).ready(function() {
+  /* prevent accidental closing of browser window */
+  {{ prevent_unsaved() }}
+
   function swapv(a,b) {
     var x = $('input[name="'+a+'"]')[0].value;
     $('input[name="'+a+'"]')[0].value = $('input[name="'+b+'"]')[0].value;

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -280,7 +280,7 @@ const subjOptions = [
   {% endfor %}
 ];
 
-$(document).ready(function() {
+document.addEventListener("DOMContentLoaded", function() {
   /* prevent accidental closing of browser window */
   {{ prevent_unsaved() }}
 

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -285,7 +285,7 @@ const subjOptions = [
   {% endfor %}
 ];
 
-$(document).ready(function() {
+document.addEventListener("DOMContentLoaded", function() {
   /* prevent accidental closing of browser window */
   {{ prevent_unsaved() }}
 

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -1,6 +1,15 @@
 {% extends "homepage.html" %}
 {% block content %}
 
+  <!-- date range picker https://github.com/dangrossman/daterangepicker jQuery plugins -->
+  <script defer
+          type="text/javascript"
+          src="{{ url_for('static', filename='daterangepicker/moment.min.js') }}"></script>
+  <script defer
+          type="text/javascript"
+          src="{{ url_for('static', filename='daterangepicker/daterangepicker.min.js') }}"></script>
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='daterangepicker/daterangepicker.css') }}" />
+
 
 <form it="talkform" action="{{ url_for('.save_talk') }}" method="POST">
   <input type="hidden" name="seminar_id" value="{{ talk.seminar_id }}"/>
@@ -252,16 +261,6 @@
   </table>
 </form>
 
-<script type="text/javascript"
-        src="https://cdn.jsdelivr.net/gh/markitup/1.x@1.1.15/markitup/jquery.markitup.js"
-        integrity="sha256-BiawY8kuGhVgPmV3XSWamEheAvBvH9VeZbzR16BdvAM="
-        crossorigin="anonymous"></script>
-{# depends on color #}
-<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='markitup.css')}}" />
-{# settings for the editor menus and the stylesheet #}
-<script type="text/javascript" src="{{ url_for('static', filename='jquery.markitup.markdown.js')}}"></script>
-<link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='markdown.css')}}" />
-
 <script type="text/javascript" src="{{ url_for('static', filename='talk_edit.js') }}"></script>
 <script type="text/javascript">
 /* prevent accidental closing of browser window */
@@ -279,10 +278,6 @@ $("#talkform :input").change(function() {
   unsaved = true;
 });
 
-$(document).ready(
-function() {
-  $('#kcontent').markItUp(myMarkdownSettings);
-});
 
 /* topic and inst selector */
 const topicOptions = [

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -254,20 +254,7 @@
 
 <script defer type="text/javascript" src="{{ url_for('static', filename='talk_edit.js') }}"></script>
 <script type="text/javascript">
-/* prevent accidental closing of browser window */
-{{ prevent_unsaved() }}
 
-/* register keyhandlers */
-$(function() {
-  $("#inp_title").keyup(delay_refresh);
-  $("#inp_abstract").keyup(delay_refresh);
-  refresh_preview();
-});
-
-// register any input change
-$("#talkform :input").change(function() {
-  unsaved = true;
-});
 
 
 /* topic and inst selector */
@@ -299,6 +286,21 @@ const subjOptions = [
 ];
 
 $(document).ready(function() {
+  /* prevent accidental closing of browser window */
+  {{ prevent_unsaved() }}
+
+  /* register keyhandlers */
+  $(function() {
+    $("#inp_title").keyup(delay_refresh);
+    $("#inp_abstract").keyup(delay_refresh);
+    refresh_preview();
+  });
+
+  // register any input change
+  $("#talkform :input").change(function() {
+    unsaved = true;
+  });
+
   makeTopicSelector(
     topicOptions,
     {% if talk.new or not talk.topics %}[]{% else %}{{ talk.topics | safe }}{% endif %},

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -1,15 +1,6 @@
 {% extends "homepage.html" %}
 {% block content %}
 
-  <!-- date range picker https://github.com/dangrossman/daterangepicker jQuery plugins -->
-  <script defer
-          type="text/javascript"
-          src="{{ url_for('static', filename='daterangepicker/moment.min.js') }}"></script>
-  <script defer
-          type="text/javascript"
-          src="{{ url_for('static', filename='daterangepicker/daterangepicker.min.js') }}"></script>
-  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='daterangepicker/daterangepicker.css') }}" />
-
 
 <form it="talkform" action="{{ url_for('.save_talk') }}" method="POST">
   <input type="hidden" name="seminar_id" value="{{ talk.seminar_id }}"/>
@@ -261,7 +252,7 @@
   </table>
 </form>
 
-<script type="text/javascript" src="{{ url_for('static', filename='talk_edit.js') }}"></script>
+<script defer type="text/javascript" src="{{ url_for('static', filename='talk_edit.js') }}"></script>
 <script type="text/javascript">
 /* prevent accidental closing of browser window */
 {{ prevent_unsaved() }}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -305,10 +305,11 @@ document.addEventListener("DOMContentLoaded", function() {
     topicOptions,
     {% if talk.new or not talk.topics %}[]{% else %}{{ talk.topics | safe }}{% endif %},
   );
+
   makeLanguageSelector(
     langOptions,
     "{{ talk.language }}");
-});
+
   makeSubjectSelector(
     subjOptions,
     {{ talk.subjects | safe }});
@@ -325,6 +326,8 @@ document.addEventListener("DOMContentLoaded", function() {
         {className: "info", position: "right"})
       }
     });
+
+});
 </script>
 
 {% endblock %}

--- a/seminars/static/knowl.js
+++ b/seminars/static/knowl.js
@@ -280,7 +280,6 @@ function knowl_handle(evt) {
 
 function knowl_register_onclick(element) {
   console.log("knowl_register_onclick");
-  console.log(element.querySelectorAll('*[knowl]'));
   element.querySelectorAll('a[knowl]').forEach(
    (knowl) => {
      knowl.onclick = debounce(knowl_handle, 500, true)

--- a/seminars/templates/base.html
+++ b/seminars/templates/base.html
@@ -83,8 +83,6 @@
     <script type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='showdown.min.js') }}"></script>
 
-    <script type="text/javascript" src="{{ url_for('static', filename='jquery.dataTables.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='jquery.dataTables.plugins.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='jquery.markitup.markdown.js') }}"></script>
 
     <script type="text/javascript" src="https://www.google.com/jsapi"></script>

--- a/seminars/templates/base.html
+++ b/seminars/templates/base.html
@@ -47,12 +47,14 @@
     <meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
 
     <!-- jQuery -->
-    <script type="text/javascript"
+    <script defer
+            type="text/javascript"
             src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"
             integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
             crossorigin="anonymous"></script>
     <!-- jQuery UI -->
-    <script type="text/javascript"
+    <script defer
+            type="text/javascript"
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"
             integrity="sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX"
             crossorigin="anonymous"></script>
@@ -61,31 +63,33 @@
           integrity="sha384-Nlo8b0yiGl7Dn+BgLn4mxhIIBU6We7aeeiulNCjHdUv/eKHx59s3anfSUjExbDxn"
           crossorigin="anonymous">
 
-    <!-- date range picker https://github.com/dangrossman/daterangepicker -->
-    <script type="text/javascript" src="{{ url_for('static', filename='daterangepicker/moment.min.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='daterangepicker/daterangepicker.min.js') }}"></script>
+    <!-- date range picker https://github.com/dangrossman/daterangepicker jQuery plugins -->
+    <script defer
+            type="text/javascript"
+            src="{{ url_for('static', filename='daterangepicker/moment.min.js') }}"></script>
+    <script defer
+            type="text/javascript"
+            src="{{ url_for('static', filename='daterangepicker/daterangepicker.min.js') }}"></script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='daterangepicker/daterangepicker.css') }}" />
 
-    <!-- multi select https://github.com/dudyn5ky1/select-pure -->
-    <script type="text/javascript" src="{{ url_for('static', filename='select-pure/dist/bundle.min.js') }}"></script>
+    <!-- notifications jQuery plugin -->
+    <script defer type="text/javascript" src="{{ url_for('static', filename='notify.min.js') }}"></script>
+
+    <!-- depends on jquery -->
+    <script defer type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
+
+    <!-- multi select https://github.com/dudyn5ky1/select-pure, vanilla JS-->
+    <script async
+            type="text/javascript"
+            src="{{ url_for('static', filename='select-pure/dist/bundle.min.js') }}"></script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='select_pure.css') }}" />
 
     <!-- for ics, ical, google calendar and select-pure x icons -->
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='fontawesome/css/all.min.css') }}"/>
 
-    <!-- notifications -->
-    <script type="text/javascript" src="{{ url_for('static', filename='notify.min.js') }}"></script>
+    <!-- handling knowls, vanilla JS -->
+    <script async type="text/javascript" src="{{ url_for('static', filename='knowl.js') }}"></script>
 
-
-    <script type="text/javascript" src="{{ url_for('static', filename='jquery.watermark.min.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='jquery.markitup.markdown.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='knowl.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='showdown.min.js') }}"></script>
-
-    <script type="text/javascript" src="{{ url_for('static', filename='jquery.markitup.markdown.js') }}"></script>
-
-    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
 
 
     <link rel="stylesheet"
@@ -93,17 +97,23 @@
           integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j"
           crossorigin="anonymous">
     <script defer
-          src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js"
-          integrity="sha384-9Nhn55MVVN0/4OFx7EE5kpFBPsEMZxKTCnA+4fqDmg12eCTqGi6+BB2LjY8brQxJ"
-          crossorigin="anonymous"></script>
+            src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js"
+            integrity="sha384-9Nhn55MVVN0/4OFx7EE5kpFBPsEMZxKTCnA+4fqDmg12eCTqGi6+BB2LjY8brQxJ"
+            crossorigin="anonymous"></script>
     <script defer
-          src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/auto-render.min.js"
-          integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI"
-          crossorigin="anonymous"></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='katex-custom.js') }}"></script>
+            src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/auto-render.min.js"
+            integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI"
+            crossorigin="anonymous"></script>
+    <script defer
+            type="text/javascript"
+            src="{{ url_for('static', filename='katex-custom.js') }}"></script>
     <link href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/copy-tex.css" rel="stylesheet" type="text/css">
-    <script src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/copy-tex.min.js" integrity="sha384-XhWAe6BtVcvEdS3FFKT7Mcft4HJjPqMQvi5V4YhzH9Qxw497jC13TupOEvjoIPy7" crossorigin="anonymous"></script>
+    <script defer
+            src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/copy-tex.min.js"
+            integrity="sha384-XhWAe6BtVcvEdS3FFKT7Mcft4HJjPqMQvi5V4YhzH9Qxw497jC13TupOEvjoIPy7"
+            crossorigin="anonymous"></script>
 
+    <script type="text/javascript" src="https://www.google.com/jsapi"></script>
     <script type="text/javascript">
 var _gaq = _gaq || [];
 _gaq.push(['_setAccount', 'UA-162873686-1']);

--- a/seminars/templates/base.html
+++ b/seminars/templates/base.html
@@ -47,7 +47,7 @@
     <meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
 
     <!-- jQuery -->
-    <script defer
+    <script
             type="text/javascript"
             src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"
             integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
@@ -62,7 +62,6 @@
           href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css"
           integrity="sha384-Nlo8b0yiGl7Dn+BgLn4mxhIIBU6We7aeeiulNCjHdUv/eKHx59s3anfSUjExbDxn"
           crossorigin="anonymous">
-
     <!-- date range picker https://github.com/dangrossman/daterangepicker jQuery plugins -->
     <script defer
             type="text/javascript"
@@ -72,11 +71,12 @@
             src="{{ url_for('static', filename='daterangepicker/daterangepicker.min.js') }}"></script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='daterangepicker/daterangepicker.css') }}" />
 
+
     <!-- notifications jQuery plugin -->
     <script defer type="text/javascript" src="{{ url_for('static', filename='notify.min.js') }}"></script>
 
-    <!-- depends on jquery -->
-    <script defer type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
+    <!-- depends on jquery and momment-->
+    <script type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
 
     <!-- multi select https://github.com/dudyn5ky1/select-pure, vanilla JS-->
     <script async

--- a/seminars/templates/base.html
+++ b/seminars/templates/base.html
@@ -47,7 +47,7 @@
     <meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
 
     <!-- jQuery -->
-    <script
+    <script defer
             type="text/javascript"
             src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"
             integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f"
@@ -76,10 +76,10 @@
     <script defer type="text/javascript" src="{{ url_for('static', filename='notify.min.js') }}"></script>
 
     <!-- depends on jquery and momment-->
-    <script type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
+    <script defer type="text/javascript" src="{{ url_for('static', filename='seminars.js') }}"></script>
 
     <!-- multi select https://github.com/dudyn5ky1/select-pure, vanilla JS-->
-    <script async
+    <script defer
             type="text/javascript"
             src="{{ url_for('static', filename='select-pure/dist/bundle.min.js') }}"></script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='select_pure.css') }}" />

--- a/seminars/templates/search.html
+++ b/seminars/templates/search.html
@@ -1,5 +1,9 @@
 {% extends 'homepage.html' %}
 
+
+
+
+
 {% block content %}
 <div class="search-container">
   <div class="container">


### PR DESCRIPTION
- marked almost all the javascript with "defer", so it gets downloaded in parallel
- replaced `$(document).ready(function() {` with `document.addEventListener("DOMContentLoaded", function() {`, so that we don't depend on jquery at the top level, and jquery can be loaded with defer.
- moved jquery dependent code inside `document.addEventListener("DOMContentLoaded", function() {`
- fixed a bug in `edit_talk.html`
- got rid of a bunch of old javascript from lmfdb that we dont'use, for example markup code that comes from editing knowls on lmfdb
