### PR TITLE
Addresses #433 and tweaks series view layout

### DIFF
--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -98,7 +98,7 @@
           </td>
         </tr>
         <tr>
-          <td>{{ KNOWL("per_day") }}</td>
+          <td>{{ ASTKNOWL("per_day") }}</td>
           <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" placeholder="1"/></td>
         </tr>
       {% else %}

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -137,7 +137,7 @@ per_day:
     The number of talks on a typical day during your conference.
     This is used only to determine the number of slots to create 
     in the scheduling grid on the "Edit schedule" page.
-    Later you can adjust the number of talks on each day there.
+    You can adjust the actual number of talks on each day there.
 start_date:
   title: Start date
   contents: |
@@ -146,14 +146,6 @@ end_date:
   title: End date
   contents: |
     The date on which your conference ends.
-seminar_start_time:
-  title: Start time
-  contents: |
-    The time of day your series usually meets, specified in 24 hour format (so 4 or 4:00 is 4 A.M.; use 16:00 for 4 P.M.)
-seminar_end_time:
-  title: End time
-  contents: |
-    The time of day your series usually ends, specified in 24 hour format (so 4 or 4:00 is 4 A.M.; use 16:00 for 4 P.M.)
 seminar_time_slots:
   title: Time slots
   contents: |

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -436,16 +436,19 @@ class WebSeminar(object):
                     if link and db.users.count({"email":rec["email"], "email_confirmed":True}):
                         namelink += "*"
                     editors.append(namelink)
-        if editors:
-            return "<tr><td>%s:</td><td>%s</td></tr>" % (label, ", ".join(editors))
-        else:
-            return ""
+        return ", ".join(editors)
 
     def show_organizers(self):
         return self._show_editors("Organizers")
 
     def show_curators(self):
         return self._show_editors("Curators", curators=True)
+
+    def num_visible_organizers(self):
+        return len([r for r in self.organizer_data if not r["curator"] and r["display"]])
+
+    def num_visible_curators(self):
+        return len([r for r in self.organizer_data if r["curator"] and r["display"]])
 
     def add_talk_link(self, ptag=True):
         if current_user.email in self.editors():

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -184,7 +184,7 @@ class WebSeminar(object):
         n = min(len(self.weekdays),len(self.time_slots))
         self.weekdays = self.weekdays[0:n]
         self.time_slots = self.time_slots[0:n]
-        self.description = self.description.capitalize()
+        self.description = self.description.capitalize() if self.description else ""
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
             if hasattr(self,"attr"):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -184,7 +184,6 @@ class WebSeminar(object):
         self.weekdays = self.weekdays[0:n]
         self.time_slots = self.time_slots[0:n]
         self.description = self.description.capitalize() if self.description else ""
-        print(self.description)
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
             if hasattr(self,"attr"):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -254,14 +254,12 @@ class WebSeminar(object):
             s = "Every third "
         prevd = -1
         for i in range(n):
+            s += ", " if i else ""
             d = self.weekdays[i]
             t = self.time_slots[i]
             if adapt:
                 d, t = adapt_weektimes (d, t, self.tz, current_user.tz)
-            if d == prevd:
-                s += (", " if len(s) else "") + t
-            else:
-                s += (", " if len(s) else "") + weekdays[d] + " " + t
+            s += t if d==prevd else (weekdays[d] + " " + t)
             prevd = d
         return s
 

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -233,7 +233,7 @@ class WebSeminar(object):
     def show_conference_dates (self, adapt=True):
         if self.is_conference:
             if self.start_date and self.end_date:
-                return self._show_date(self.start_date) + " to " + self.show_date(self.end_date)
+                return self._show_date(self.start_date) + " to " + self._show_date(self.end_date)
             else:
                 return "TBA"
         else:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -184,6 +184,7 @@ class WebSeminar(object):
         n = min(len(self.weekdays),len(self.time_slots))
         self.weekdays = self.weekdays[0:n]
         self.time_slots = self.time_slots[0:n]
+        self.description = self.description.capitalize()
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
             if hasattr(self,"attr"):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -185,7 +185,7 @@ class WebSeminar(object):
         self.weekdays = self.weekdays[0:n]
         self.time_slots = self.time_slots[0:n]
         self.description = self.description.capitalize() if self.description else ""
-        print self.description
+        print(self.description)
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
             if hasattr(self,"attr"):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -233,7 +233,10 @@ class WebSeminar(object):
     def show_conference_dates (self, adapt=True):
         if self.is_conference:
             if self.start_date and self.end_date:
-                return self._show_date(self.start_date) + " to " + self._show_date(self.end_date)
+                if self.start_date == self.end_date:
+                    return self._show_date(self.start_date)
+                else:
+                    return self._show_date(self.start_date) + " to " + self._show_date(self.end_date)
             else:
                 return "TBA"
         else:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -141,19 +141,18 @@ class WebSeminar(object):
         if self.frequency is None:
             self.weekdays = []
             self.time_slots = []
-            return
-        if self.frequency > 1 and self.frequency <= 7:
-            self.frequency = 7
-        elif self.frequency > 7 and self.frequency <= 14:
-            self.frequency = 14
-        elif self.frequency > 14 and self.frequency <= 21:
-            self.frequency = 21
-        else:
-            self.frequency = None
-            self.weekdays = []
-            self.time_slots = []
-            return
-        if not self.weekdays or not self.time_slots:
+        else
+            if self.frequency > 1 and self.frequency <= 7:
+                self.frequency = 7
+            elif self.frequency > 7 and self.frequency <= 14:
+                self.frequency = 14
+            elif self.frequency > 14 and self.frequency <= 21:
+                self.frequency = 21
+            else:
+                self.frequency = None
+                self.weekdays = []
+                self.time_slots = []
+        if self.frequency and (not self.weekdays or not self.time_slots):
             self.weekdays = []
             self.time_slots = []
             if self.weekday is not None and self.start_time is not None and self.end_time is not None:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -185,6 +185,7 @@ class WebSeminar(object):
         self.weekdays = self.weekdays[0:n]
         self.time_slots = self.time_slots[0:n]
         self.description = self.description.capitalize() if self.description else ""
+        print self.description
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
             if hasattr(self,"attr"):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -251,7 +251,7 @@ class WebSeminar(object):
         elif self.frequency == 14:
             s = "Every other "
         elif self.frequency == 21:
-            s = "Everyt third "
+            s = "Every third "
         prevd = -1
         for i in range(n):
             d = self.weekdays[i]
@@ -259,9 +259,9 @@ class WebSeminar(object):
             if adapt:
                 d, t = adapt_weektimes (d, t, self.tz, current_user.tz)
             if d == prevd:
-                s += ", " + t
+                s += (", " if len(s) else "") + t
             else:
-                s += ", " + weekdays[d] + " " + t
+                s += (", " if len(s) else "") + weekdays[d] + " " + t
             prevd = d
         return s
 

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -141,7 +141,7 @@ class WebSeminar(object):
         if self.frequency is None:
             self.weekdays = []
             self.time_slots = []
-        else
+        else:
             if self.frequency > 1 and self.frequency <= 7:
                 self.frequency = 7
             elif self.frequency > 7 and self.frequency <= 14:

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -32,7 +32,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.description %}
 <tr>
   <td style="padding:0px;">Description:</td>
-  <td>{{(seminar.description | blanknone) | safe }}</td>
+  <td>{{seminar.description.capitalize() | safe }}</td>
 </tr>
 {% endif %}
 {% if seminar.is_conference %}
@@ -49,17 +49,17 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% set n = seminar.num_visible_organizers() %}
 {% if n > 0 %}
 <tr>
-  <td style="padding:0px;">Organizer{%if n > 1 %}s{% endif %}</td>
+  <td style="padding:0px;">Organizer{%if n > 1 %}s{% endif %}:</td>
   <td>{{ seminar.show_organizers() | safe }}</td>
 </tr>
 {% endif %}
 {% set n = seminar.num_visible_curators() %}
 {% if n > 0 %}
 <tr>
-  <td style="padding:0px;">Curator{%if n > 1 %}s{% endif %}</td>
+  <td style="padding:0px;">Curator{%if n > 1 %}s{% endif %}:</td>
   <td>{{ seminar.show_curators() | safe }}</td>
 </tr>
-<tr><td style="padding:0px;"></td><td class="forminfo">*contact</td></tr>
+<tr><td style="padding:0px;"></td><td class="forminfo">*contact for this listing</td></tr>
 {% endif %}
 </table>
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -60,6 +60,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <td>{{ seminar.show_curators() | safe }}</td>
 </tr>
 <tr><td></td><td class="forminfo">*contact</td></tr>
+{% endif %}
 </table>
 
 {% if seminar.comments %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -22,28 +22,19 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 </p>
 {% endif %}
 {% if seminar.topics %}
-<p>
-  {{seminar.show_topics() | safe}}
-</p>
+  <p>{{seminar.show_topics() | safe}}</p>
 {% endif %}
 {% if seminar.institutions %}
-  <p>
-    {{seminar.show_institutions() | safe}}
-  </p>
+  <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
 {% if seminar.description %}
-  <p>
-    Description: {{(seminar.description | blanknone) | safe }}
-  </p>
+  <p>Description: {{(seminar.description | blanknone) | safe }}</p>
 {% endif %}
-
-{% if seminar.weekday is not none or seminar.start_time %}
-  <p>{{ seminar.show_weektime_and_duration() }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}. {% endif %}</p>
-  {% if (not seminar.online or seminar.room) and seminar.timezone != current_user.timezone %}
-    <p>{{ seminar.show_weektime_and_duration(adapt=False) }} in series time zone, {{ seminar.timezone.replace("_", " ") }}.</p>
-  {% endif %}
+{% if seminar.is_conference %}
+  <p>Conference dates: {{ seminar.show_dates() | safe }}</p>
+{% else %}
+  <p>Seminar times: {{(seminar.show_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.</p>
 {% endif %}
-
 
 <table>
   {{ seminar.show_organizers() | safe }}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,7 +31,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>Description: {{(seminar.description | blanknone) | safe }}</p>
 {% endif %}
 {% if seminar.is_conference %}
-  <p>Conference dates: {{ seminar.show_dates() | safe }}</p>
+  <p>Conference dates: {{ seminar.show_conference_dates() | safe }}</p>
 {% else %}
   <p>Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}: {{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
 {% endif %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -33,7 +33,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.is_conference %}
   <p>Conference dates: {{ seminar.show_dates() | safe }}</p>
 {% else %}
-  <p>Seminar times: {{seminar.show_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
+  <p>Seminar times: {{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
 {% endif %}
 
 <table>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -28,10 +28,10 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
 
-<table style="margin-left:0px">
+<table style="padding:0px">
 {% if seminar.description %}
 <tr>
-  <td>Description:</td>
+  <td style="padding:0px">Description:</td>
   <td>{{(seminar.description | blanknone) | safe }}</td>
 </tr>
 {% endif %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -33,7 +33,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.is_conference %}
   <p>Conference dates: {{ seminar.show_dates() | safe }}</p>
 {% else %}
-  <p>Seminar times: {{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
+  <p>Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}: {{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
 {% endif %}
 
 <table>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -28,7 +28,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
 
-<table>
+<table style="border-collapse:separate; border-spacing: 20px 0;">
 {% if seminar.description %}
 <tr>
   <td style="padding:0px;">Description:</td>
@@ -42,24 +42,24 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 </tr>
 {% else %}
 <tr>
-  <td>Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}:</td>
+  <td style="padding:0px;">Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}:</td>
   <td>{{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</td>
 </tr>
 {% endif %}
 {% set n = seminar.num_visible_organizers() %}
 {% if n > 0 %}
 <tr>
-  <td>Organizer{%if n > 1 %}s{% endif %}</td>
+  <td style="padding:0px;">Organizer{%if n > 1 %}s{% endif %}</td>
   <td>{{ seminar.show_organizers() | safe }}</td>
 </tr>
 {% endif %}
 {% set n = seminar.num_visible_curators() %}
 {% if n > 0 %}
 <tr>
-  <td>Organizer{%if n > 1 %}s{% endif %}</td>
+  <td style="padding:0px;">Curator{%if n > 1 %}s{% endif %}</td>
   <td>{{ seminar.show_curators() | safe }}</td>
 </tr>
-<tr><td></td><td class="forminfo">*contact</td></tr>
+<tr><td style="padding:0px;"></td><td class="forminfo">*contact</td></tr>
 {% endif %}
 </table>
 

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -28,7 +28,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
 
-<table style="margin:0px">
+<table style="margin-left:0px">
 {% if seminar.description %}
 <tr>
   <td>Description:</td>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -32,7 +32,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.description %}
 <tr>
   <td style="padding:0px;">Description:</td>
-  <td>{{seminar.description.capitalize() | safe }}</td>
+  <td>{{seminar.description | safe }}</td>
 </tr>
 {% endif %}
 {% if seminar.is_conference %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -28,16 +28,16 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
 
-<table style="padding:0px">
+<table>
 {% if seminar.description %}
 <tr>
-  <td style="padding:0px">Description:</td>
+  <td style="padding:0px;">Description:</td>
   <td>{{(seminar.description | blanknone) | safe }}</td>
 </tr>
 {% endif %}
 {% if seminar.is_conference %}
 <tr>
-  <td>Conference date{% if seminar.start_date != seminar.end_date %}s{% endif %}:</td>
+  <td style="padding:0px;">Conference date{% if seminar.start_date != seminar.end_date %}s{% endif %}:</td>
   <td>{{ seminar.show_conference_dates() | safe }}</td>
 </tr>
 {% else %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -27,22 +27,40 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.institutions %}
   <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
+
+<table style="margin:0px">
 {% if seminar.description %}
-  <p>Description: {{(seminar.description | blanknone) | safe }}</p>
+<tr>
+  <td>Description:</td>
+  <td>{{(seminar.description | blanknone) | safe }}</td>
+</tr>
 {% endif %}
 {% if seminar.is_conference %}
-  <p>Conference date{% if seminar.start_date != seminar.end_date %}s{% endif %}: {{ seminar.show_conference_dates() | safe }}</p>
+<tr>
+  <td>Conference date{% if seminar.start_date != seminar.end_date %}s{% endif %}:</td>
+  <td>{{ seminar.show_conference_dates() | safe }}</td>
+</tr>
 {% else %}
-  <p>Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}: {{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
+<tr>
+  <td>Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}:</td>
+  <td>{{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</td>
+</tr>
 {% endif %}
-
-<table>
-  {{ seminar.show_organizers() | safe }}
-  {{ seminar.show_curators() | safe }}
-  <td></td><td class="forminfo">*contact</td>
+{% set n = seminar.num_visible_organizers() %}
+{% if n > 0 %}
+<tr>
+  <td>Organizer{%if n > 1 %}s{% endif %}</td>
+  <td>{{ seminar.show_organizers() | safe }}</td>
+</tr>
+{% endif %}
+{% set n = seminar.num_visible_curators() %}
+{% if n > 0 %}
+<tr>
+  <td>Organizer{%if n > 1 %}s{% endif %}</td>
+  <td>{{ seminar.show_curators() | safe }}</td>
+</tr>
+<tr><td></td><td class="forminfo">*contact</td></tr>
 </table>
-
-
 
 {% if seminar.comments %}
   <hr>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -59,8 +59,8 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <td style="padding:0px;">Curator{%if n > 1 %}s{% endif %}:</td>
   <td>{{ seminar.show_curators() | safe }}</td>
 </tr>
-<tr><td style="padding:0px;"></td><td class="forminfo">*contact for this listing</td></tr>
 {% endif %}
+<tr><td style="padding:0px;"></td><td class="forminfo">*contact for this listing</td></tr>
 </table>
 
 {% if seminar.comments %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -33,7 +33,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.is_conference %}
   <p>Conference dates: {{ seminar.show_dates() | safe }}</p>
 {% else %}
-  <p>Seminar times: {{(seminar.show_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.</p>
+  <p>Seminar times: {{seminar.show_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.</p>
 {% endif %}
 
 <table>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -28,7 +28,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>{{seminar.show_institutions() | safe}}</p>
 {% endif %}
 
-<table style="border-collapse:separate; border-spacing: 20px 0;">
+<table style="border-collapse:separate; border-spacing: 0px 10px;">
 {% if seminar.description %}
 <tr>
   <td style="padding:0px;">Description:</td>

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -31,7 +31,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
   <p>Description: {{(seminar.description | blanknone) | safe }}</p>
 {% endif %}
 {% if seminar.is_conference %}
-  <p>Conference dates: {{ seminar.show_conference_dates() | safe }}</p>
+  <p>Conference date{% if seminar.start_date != seminar.end_date %}s{% endif %}: {{ seminar.show_conference_dates() | safe }}</p>
 {% else %}
   <p>Seminar time{% if (seminar.weekdays | length) > 1 %}s{% endif %}: {{seminar.show_seminar_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
 {% endif %}

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -33,7 +33,7 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% if seminar.is_conference %}
   <p>Conference dates: {{ seminar.show_dates() | safe }}</p>
 {% else %}
-  <p>Seminar times: {{seminar.show_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}.</p>
+  <p>Seminar times: {{seminar.show_times() | safe }}{% if seminar.timezone != current_user.timezone %} in your time zone, {{ current_user.timezone.replace("_", " ") }}{% endif %}.</p>
 {% endif %}
 
 <table>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -60,9 +60,21 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
 
   <div style="font-size: 90%;">
     <table>
-      {{ seminar.show_organizers() | safe }}
-      {{ seminar.show_curators() | safe }}
-      <tr><td></td><td class="forminfo">*contact</td></tr>
+      {% set n = seminar.num_visible_organizers() %}
+      {% if n > 0 %}
+      <tr>
+        <td style="padding:0px;">Organizer{%if n > 1 %}s{% endif %}:</td>
+        <td>{{ seminar.show_organizers() | safe }}</td>
+      </tr>
+      {% endif %}
+      {% set n = seminar.num_visible_curators() %}
+      {% if n > 0 %}
+      <tr>
+        <td style="padding:0px;">Curator{%if n > 1 %}s{% endif %}:</td>
+        <td>{{ seminar.show_curators() | safe }}</td>
+      </tr>
+      <tr><td style="padding:0px;"></td><td class="forminfo">*contact for this listing</td></tr>
+      {% endif %}
     </table>
   </div>
   <hr>

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -58,7 +58,7 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   {{talk.seminar.show_comments(prefix="<b>Series comments: </b>") | safe}}
   {% endif %}
 
-  <div style="font-size: 90%;">
+  <div>
     <table>
       {% set n = seminar.num_visible_organizers() %}
       {% if n > 0 %}
@@ -73,8 +73,8 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
         <td style="padding:0px;">Curator{%if n > 1 %}s{% endif %}:</td>
         <td>{{ seminar.show_curators() | safe }}</td>
       </tr>
-      <tr><td style="padding:0px;"></td><td class="forminfo">*contact for this listing</td></tr>
       {% endif %}
+      <tr><td style="padding:0px;"></td><td class="forminfo">*contact for this listing</td></tr>
     </table>
   </div>
   <hr>

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -65,7 +65,7 @@ def daytime_minutes(s):
     return 60*int(t[0])+int(t[1])
 
 def daytimes_start_minutes(s):
-    return daytime_minutes(s.split(':')[0])
+    return daytime_minutes(s.split('-')[0])
 
 def midnight(date, tz):
     return localize_time(datetime.combine(date, maketime()), tz)

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -70,6 +70,10 @@ def daytimes_start_minutes(s):
 def midnight(date, tz):
     return localize_time(datetime.combine(date, maketime()), tz)
 
+def weekstart(date, tz):
+    t = midnight(date,tz)
+    return t - timedelta(days=1)*t.weekday()
+
 def date_and_daytimes_to_times(date, s, tz):
     d = localize_time(datetime.combine(date, maketime()), tz)
     m = timedelta(minutes=1)
@@ -85,11 +89,14 @@ def daytimes_early(s):
     start, end = daytime_minutes(t[0]), daytime_minutes(t[1])
     return start > end or start < 6*60
 
-def daytimes_long(s):
+def daytimes_minutes(s):
     t = s.split('-')
     start, end = daytime_minutes(t[0]), daytime_minutes(t[1])
     len = end - start if end > start else 24*60-start + end
-    return len > 8*60
+    return len    
+
+def daytimes_long(s):
+    return daytimes_minutes(s) > 8*60
 
 def make_links(x):
     """ Given a blob of text looks for URLs (beggining with http:// or https://) and makes them hyperlinks. """
@@ -430,28 +437,23 @@ def adapt_datetime(t, newtz=None):
     return t.astimezone(newtz)
 
 
-def adapt_weektime(t, oldtz, newtz=None, weekday=None):
+def adapt_weektimes(weekday, daytimes, oldtz, newtz):
     """
-    Converts a weekday and time in a given time zone to the specified new time zone using the next valid date.
+    Converts a weekday in [0,7] and daytimes HH:MM-HH:MM from oldtz to newtz (returns integer in [0,7] and string HH:MM-HH:MM).
+    Note that weekday is for the start time, the end time could be the following day (this is implied by end time <= start time)
     """
     if isinstance(oldtz, str):
         oldtz = pytz.timezone(oldtz)
-    now = datetime.now(oldtz)
-    # The t we obtain from psycopg2 comes with tzinfo, but we need to forget it
-    # in order to compare with now.time()
-    tblank = t.replace(tzinfo=None).time()
-    if weekday is None:
-        days_ahead = 0 if now.time() <= tblank else 1
-    else:
-        days_ahead = weekday - now.weekday()
-        if days_ahead < 0 or (days_ahead == 0 and now.time() > tblank):
-            days_ahead += 7
-    next_t = oldtz.localize(datetime.combine(now.date() + timedelta(days=days_ahead), t.time()))
-    next_t = adapt_datetime(next_t, newtz)
-    if weekday is None:
-        return None, next_t.time()
-    else:
-        return next_t.weekday(), next_t.time()
+    if isinstance(newtz, str):
+        newtz = pytz.timezone(newtz)
+    if newtz == oldtz:
+        return weekday, daytimes
+    oneday = timedelta(days=1)
+    oneminute = timedelta(minutes=1)
+    start = weekstart(datetime.now(oldtz),oldtz) + weekday*oneday + daytimes_start_minutes(daytimes)*oneminute
+    start = adapt_datetime(start, newtz=newtz)
+    end = start + daytimes_minutes(daytimes)*oneminute
+    return start.weekday(), start.strftime("%H:%M") + "-" + end.strftime("%H:%M")
 
 
 def process_user_input(inp, col, typ, tz):


### PR DESCRIPTION
Seminar times and conference dates are now shown on the View series page (so in particular you can tell them apart).  Also includes a bunch of cleanup to remove obsolete code that used weekday, start_time, end_time, and capitalizes the short description (this was about 50/50 in the data and on the new view series page I think it looks better capitalized).
