### PR TITLE
Add length restrictions to all input fields

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -651,9 +651,9 @@ def save_institution():
     if not errmsgs and not data["homepage"]:
         errmsgs.append("Institution homepage cannot be blank.")
     if new and db.institutions.count({'name':data["name"]}):
-        errmsgs.append(format_errmsgs("An institution named %s already exists.  Please add disambiguating information to the name.", data["name"]))
+        errmsgs.append(format_errmsg("An institution named %s already exists.  Please add disambiguating information to the name.", data["name"]))
     if not new and data["name"] != institution.name and db.institutions.count({'name':data["name"]}):
-        errmsgs.append(format_errmsgs("Unable to change institution name to %s, there is another insituttion with the same name.", data["name"]))
+        errmsgs.append(format_errmsg("Unable to change institution name to %s, there is another insituttion with the same name.", data["name"]))
     # Don't try to create new_version using invalid input
     if errmsgs:
         return show_input_errors(errmsgs)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -571,6 +571,8 @@ def edit_institution():
     else:
         data = request.args
     shortname = data.get("shortname", "")
+    if data.get("cancel") == "yes":
+        flash("Changes discarded.")
     new = data.get("new") == "yes"
     name = data.get("name", "")
     resp, institution = can_edit_institution(shortname, name, new)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -607,6 +607,7 @@ def save_institution():
     if raw_data.get("submit") == "cancel":
         if new:
             return redirect(url_for("list_institutions"), 302)
+        flash("Changes discarded")
         return redirect(url_for(".edit_institution", shortname=shortname), 302)
 
     data = {}

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -650,6 +650,10 @@ def save_institution():
         errmsgs.append("Institution name cannot be blank.")
     if not errmsgs and not data["homepage"]:
         errmsgs.append("Institution homepage cannot be blank.")
+    if new and db.institutions.count({'name':data["name"]}):
+        errmsgs.append(format_errmsgs("An institution named %s already exists.  Please add disambiguating information to the name.", data["name"]))
+    if not new and data["name"] != institution.name and db.institutions.count({'name':data["name"]}):
+        errmsgs.append(format_errmsgs("Unable to change institution name to %s, there is another insituttion with the same name.", data["name"]))
     # Don't try to create new_version using invalid input
     if errmsgs:
         return show_input_errors(errmsgs)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -24,6 +24,7 @@ from seminars.utils import (
     daytimes_early,
     daytimes_long,
     date_and_daytimes_to_times,
+    maxlength,
 )
 from seminars.seminar import (
     WebSeminar,
@@ -58,7 +59,6 @@ from dateutil.parser import parse as parse_time
 import pytz
 
 SCHEDULE_LEN = 15  # Number of weeks to show in edit_seminar_schedule
-MAX_SLOTS = 12  # Max time slots in a seminar series, must be a multiple of 3
 
 
 @create.route("manage/")
@@ -129,6 +129,7 @@ WHERE {Tsems}.{Cowner} ~~* %s AND {Ttalks}.{Cdel} = %s AND {Tsems}.{Cdel} = %s
         deleted_talks=deleted_talks,
         institution_known=institution_known,
         institutions=institutions(),
+        maxlength=maxlength,
         section=manage,
         subsection="home",
         title=manage,
@@ -197,7 +198,7 @@ def edit_seminar():
         institutions=institutions(),
         short_weekdays=short_weekdays,
         timezones=timezones,
-        max_slots=MAX_SLOTS,
+        maxlength=maxlength,
         lock=lock,
     )
 
@@ -223,6 +224,7 @@ def delete_seminar(shortname):
             institutions=institutions(),
             weekdays=weekdays,
             timezones=timezones,
+            maxlength=maxlength,
             lock=lock,
         )
 
@@ -312,6 +314,7 @@ def delete_talk(semid, semctr):
             subsection="edittalk",
             institutions=institutions(),
             timezones=timezones,
+            maxlength=maxlength,
         )
 
     if not talk.user_can_delete():
@@ -441,7 +444,7 @@ def save_seminar():
         data["timezone"] = WebInstitution(data["institutions"][0]).timezone
     data["weekdays"] = []
     data["time_slots"] = []
-    for i in range(MAX_SLOTS):
+    for i in range(maxlength["time_slots"]):
         weekday = daytimes = None
         try:
             col = "weekday" + str(i)
@@ -585,6 +588,7 @@ def edit_institution():
         title=title,
         section="Manage",
         subsection="editinst",
+        maxlength=maxlength,
     )
 
 
@@ -702,6 +706,7 @@ def edit_talk():
         subsection="edittalk",
         institutions=institutions(),
         timezones=timezones,
+        maxlength=maxlength,
         token=token,
         **extras
     )
@@ -908,6 +913,7 @@ def edit_seminar_schedule():
         schedule=schedule,
         section="Manage",
         subsection="schedule",
+        maxlength=maxlength,
     )
 
 

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -604,6 +604,10 @@ def save_institution():
     resp, institution = can_edit_institution(shortname, name, new)
     if resp is not None:
         return resp
+    if raw_data.get("submit") == "cancel":
+        if new:
+            return redirect(url_for("list_institutions"), 302)
+        return redirect(url_for(".edit_institution", shortname=shortname), 302)
 
     data = {}
     data["timezone"] = tz = raw_data.get("timezone", "UTC")

--- a/seminars/create/templates/create_index.html
+++ b/seminars/create/templates/create_index.html
@@ -63,12 +63,12 @@ You may want to <a href="{{ url_for('list_institutions') }}">add your institutio
     </tr>
     <tr>
       <td>{{ ASTKNOWL("seminar_name") }}</td>
-      <td><input name="name" style="width:500px;" maxlength="100" placeholder="Thule topology colloquium series"/></td>
+      <td><input name="name" style="width:500px;" placeholder="Thule topology colloquium series" maxlength="{{ maxlength['name'] /></td>
       <td class="forminfo">Capitalize first word and proper nouns.</td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("seminar_shortname") }}</td>
-      <td><input name="shortname" style="width:500px;" placeholder="TeaAndTopology" maxlength="32"/></td>
+      <td><input name="shortname" style="width:500px;" placeholder="TeaAndTopology" maxlength="{{ maxlength['shortname'] /></td>
       <td class="forminfo">Use 3-32 characters, no spaces.
     </tr>
     {% if topdomain != "mathseminars.org" %} {# FIXME: temporary measure during addition of physics #}

--- a/seminars/create/templates/edit_institution.html
+++ b/seminars/create/templates/edit_institution.html
@@ -49,7 +49,7 @@
     <table>
     <tr>
       <td><button type="submit" onclick="unsaved = false; return true;">Save</button></td>
-      <td><button type="submit" onclick="unsaved = false;" formmethod="get" formaction="{% if institution.new %}{{ url_for('list_institutions') }}{% else %}{{ url_for('show_institution', shortname=institution.shortname) }}{% endif %}">Cancel</button></td>
+      <td><button type="submit" onclick="unsaved = false;" formmethod="get" formaction="{% if institution.new %}{{ url_for('list_institutions') }}{% else %}{{ url_for('edit_institution', shortname=institution.shortname, cancel="yes") }}{% endif %}">Cancel</button></td>
     </tr>
   </table>
 </form>

--- a/seminars/create/templates/edit_institution.html
+++ b/seminars/create/templates/edit_institution.html
@@ -11,7 +11,7 @@
     </tr>
     <tr>
       <td>{{ ASTKNOWL('institution_name') }}</td>
-      <td><input name="name" id="sname" value="{{ institution.name | blanknone }}" style="width:500px;" /></td>
+      <td><input name="name" id="sname" value="{{ institution.name | blanknone }}" style="width:500px;" maxlength="{{ maxlength['institutions.name'] }}"/></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL('institution_type') }}</td>
@@ -25,11 +25,11 @@
     </tr>
     <tr>
       <td>{{ ASTKNOWL('institution_homepage') }}</td>
-      <td><input style="width:500px;" name="homepage" value="{{ institution.homepage | blanknone }}" placeholder="https://mit.edu/"/></td>
+      <td><input style="width:500px;" name="homepage" value="{{ institution.homepage | blanknone }}" maxlength="{{ maxlength['homepage'] }}" placeholder="https://mit.edu/"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL('institution_city') }}</td>
-      <td><input name="city" value="{{ institution.city | blanknone }}" style="width:500px;" placeholder="Cambridge, MA, USA"/></td>
+      <td><input name="city" value="{{ institution.city | blanknone }}" style="width:500px;" maxlength="{{ maxlength['city'] }}" placeholder="Cambridge, MA, USA"/></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL('institution_timezone') }}</td>
@@ -43,12 +43,15 @@
     </tr>
     <tr>
       <td>{{ ASTKNOWL('institution_admin') }}</td>
-      <td><input name="admin" value="{{ institution.admin }}" style="width:500px;" /></td>
+      <td><input name="admin" value="{{ institution.admin }}" style="width:500px;" maxlength="{{ maxlength['admin'] }}"/></td>
     </tr>
   </table>
-  <button type="submit" onclick="unsaved = false; return true;">Save</button>
-
-  <a style="margin-left: 30px" onclick="unsaved = false;" href="{% if institution.new %}{{ url_for('list_institutions') }}{% else %}{{ url_for('show_institution', shortname=institution.shortname) }}{% endif %}">Cancel creation</a>
+    <table>
+    <tr>
+      <td><button type="submit" onclick="unsaved = false; return true;">Save</button></td>
+      <td><button type="submit" onclick="unsaved = false;" formmethod="get" formaction="{% if institution.new %}{{ url_for('list_institutions') }}{% else %}{{ url_for('show_institution', shortname=institution.shortname) }}{% endif %}">Cancel</button></td>
+    </tr>
+  </table>
 </form>
 <script type="text/javascript">
 /* prevent accidental closing of browser window */

--- a/seminars/create/templates/edit_institution.html
+++ b/seminars/create/templates/edit_institution.html
@@ -48,8 +48,8 @@
   </table>
     <table>
     <tr>
-      <td><button type="submit" onclick="unsaved = false; return true;">Save</button></td>
-      <td><button type="submit" onclick="unsaved = false;" formmethod="get" formaction="{% if institution.new %}{{ url_for('list_institutions') }}{% else %}{{ url_for('edit_institution', shortname=institution.shortname, cancel="yes") }}{% endif %}">Cancel</button></td>
+      <td><button type="submit" name="submit" value="save" onclick="unsaved = false; return true;">Save</button></td>
+      <td><button type="submit" name="submit" value="cancel" onclick="unsaved = false;" return true;">Cancel</button></td>
     </tr>
   </table>
 </form>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -33,16 +33,16 @@
         </tr>
         <tr>
           <td>{{ ASTKNOWL("seminar_name") }}</td>
-          <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" /></td>
+          <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" maxlength="{{ maxlength['name'] }}"/></td>
           <td class="forminfo" />Capitalize only the first word and proper nouns.</td>
         </tr>
         <tr>
           <td>{{ KNOWL("seminar_description") }}</td>
-          <td><input name="description" value="{{ seminar.description | blanknone }}" style="width:600px;" placeholder="research seminar" maxlength="60"/></td>
+          <td><input name="description" value="{{ seminar.description | blanknone }}" style="width:600px;" maxlength="{{ maxlength['description'] }}" placeholder="research seminar" /></td>
         </tr>
         <tr>
           <td>{{ KNOWL("seminar_homepage") }}</td>
-          <td><input name="homepage" value="{{ seminar.homepage | blanknone }}" style="width:600px;" placeholder="https://example.org"/></td>
+          <td><input name="homepage" value="{{ seminar.homepage | blanknone }}" style="width:600px;" maxlength="{{ maxlength['homepage'] }}" placeholder="https://example.org"/></td>
         </tr>
         <tr>
           <td>{{ KNOWL("institutions") }}</td>
@@ -117,7 +117,7 @@
         </tr>
       </table>
       <table class='times' {% if not seminar.frequency %} style="display:none;" {% endif %}>
-        {% for i in range(max_slots//3) %}
+        {% for i in range(maxlength["time_slots"]//3) %}
           <tr style="width:750px;">
             {% if i == 0 %}
               <td style="margin-right:0px;">{{ KNOWL("seminar_time_slots") }}</td>
@@ -148,7 +148,7 @@
     {% endif %}
         <tr>
           <td style="width:150px; padding-top: 20px">{{ KNOWL("room") }}</td>
-          <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" placeholder="Room 2-190 in the Simons building"/></td>
+          <td style="padding-top: 20px"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" maxlength="{{ maxlength['room'] }}" placeholder="Room 2-190 in the Simons building"/></td>
         </tr>
         <tr>
           <td>{{ ASTKNOWL("online") }}</td>
@@ -161,7 +161,7 @@
         </tr>
         <tr>
           <td>{{ KNOWL("live_link") }}</td>
-          <td><input name="live_link" value="{{ seminar.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
+          <td><input name="live_link" value="{{ seminar.live_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['live_link'] }}" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
           <td class="forminfo" />If link varies, enter "See comments" and put instructions in Comments.</td>
         </tr>
         <tr>
@@ -178,7 +178,7 @@
           <td colspan="2" style="padding-top: 10px">{{ KNOWL("comments") }}</td>
         </tr>
         <tr>
-          <td colspan="2"><textarea cols="89" rows="6" style="width:770px;" name="comments" placeholder="Instructions for obtaining the livestream link?  Directions to the room?  HTML and $\TeX$ symbols are OK here.">{{ seminar.comments | blanknone }}</textarea></td>
+          <td colspan="2"><textarea cols="89" rows="6" style="width:770px;" name="comments" maxlength="{{ maxlength['comments'] }}" placeholder="Instructions for obtaining the livestream link?  Directions to the room?  HTML and $\TeX$ symbols are OK here.">{{ seminar.comments | blanknone }}</textarea></td>
         </tr>
       </table>
       <h3>Organizers</h3>
@@ -194,7 +194,7 @@
           <td align="center">{{ KNOWL("organizer") }}</td>
           <td align="center">{{ KNOWL("display") }}</td>
         </thead>
-        {% for i in range(10) %}
+        {% for i in range(max_length["organizers"]) %}
         <tr>
           {% if i > 0 and i < (seminar.organizer_data | length) %}
             <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>
@@ -203,13 +203,13 @@
           {% endif %}
           {% if i < (seminar.organizer_data | length) %}
             <td>
-              <input name="org_full_name{{i}}" value="{{ seminar.organizer_data[i].get('full_name') | blanknone }}" style="width:180px"/>
+              <input name="org_full_name{{i}}" value="{{ seminar.organizer_data[i].get('full_name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['full_name'] }}" />
             </td>
             <td>
-              <input name="org_homepage{{i}}" value="{{ seminar.organizer_data[i].get('homepage') | blanknone }}" style="width:220px"/>
+              <input name="org_homepage{{i}}" value="{{ seminar.organizer_data[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
             </td>
             <td>
-              <input name="org_email{{i}}" value="{{ seminar.organizer_data[i].get('email') | blanknone }}" style="width:220px"/>
+              <input name="org_email{{i}}" value="{{ seminar.organizer_data[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
             </td>
             <td align="center">
               {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -194,7 +194,7 @@
           <td align="center">{{ KNOWL("organizer") }}</td>
           <td align="center">{{ KNOWL("display") }}</td>
         </thead>
-        {% for i in range(max_length["organizers"]) %}
+        {% for i in range(maxlength["organizers"]) %}
         <tr>
           {% if i > 0 and i < (seminar.organizer_data | length) %}
             <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -310,7 +310,7 @@ document.addEventListener("DOMContentLoaded", function() {
   {% endfor %}
   function showplusminus(n) {
     document.getElementById('slotminus').style.visibility = ( n > 1 ? 'visible' : 'hidden' );
-    document.getElementById('slotplus').style.visibility = ( n < {{ max_slots }} ? 'visible' : 'hidden' );
+    document.getElementById('slotplus').style.visibility = ( n < {{ maxlength["time_slots"] }} ? 'visible' : 'hidden' );
   }
   $("a.slotplus").click(function(e){
     e.preventDefault();

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -50,8 +50,8 @@
       {% if schedule[i][2] %}
         {% set talk = schedule[i][2] %}
         <td class="speakerinp"><input name="speaker{{i}}" value="{{ talk.speaker | blanknone }}" maxlength="{{ maxlength['speaker'] }}"/></td>
-        <td class="emailinp"><input name="speaker_email{{i}}" value="{{ talk.speaker_email | blanknone }}" maxlength="{{ maxlength['email'] }}"/></td>
-        <td class="affiliationinp"><input name="speaker_affiliation{{i}}" value="{{ talk.speaker_affiliation | blanknone }}" maxlength="{{ maxlength['affiliation'] }}"/></td>
+        <td class="emailinp"><input name="speaker_email{{i}}" value="{{ talk.speaker_email | blanknone }}" maxlength="{{ maxlength['speaker_email'] }}"/></td>
+        <td class="affiliationinp"><input name="speaker_affiliation{{i}}" value="{{ talk.speaker_affiliation | blanknone }}" maxlength="{{ maxlength['speaker_affiliation'] }}"/></td>
         <td class="titleinp"><input name="title{{i}}" value="{{ talk.title | blanknone }}" maxlength="{{ maxlength['title'] }}"/></td>
         <td align="left" style="padding-right:0px;"><input type="checkbox" name="hidden{{i}}" value="yes"{% if talk.hidden %} checked {% endif %} /></td>
         <td align="left">{{ talk.details_link() | safe }}</td>

--- a/seminars/create/templates/edit_seminar_schedule.html
+++ b/seminars/create/templates/edit_seminar_schedule.html
@@ -49,18 +49,18 @@
       <td class="timerange"><input style="width: 96px;" name="time{{i}}" value="{{ schedule[i][1] }}" placeholder="15:00-16:00" /></td>
       {% if schedule[i][2] %}
         {% set talk = schedule[i][2] %}
-        <td class="speakerinp"><input name="speaker{{i}}" value="{{ talk.speaker | blanknone }}" /></td>
-        <td class="emailinp"><input name="speaker_email{{i}}" value="{{ talk.speaker_email | blanknone }}" /></td>
-        <td class="affiliationinp"><input name="speaker_affiliation{{i}}" value="{{ talk.speaker_affiliation | blanknone }}" /></td>
-        <td class="titleinp"><input name="title{{i}}" value="{{ talk.title | blanknone }}" /></td>
+        <td class="speakerinp"><input name="speaker{{i}}" value="{{ talk.speaker | blanknone }}" maxlength="{{ maxlength['speaker'] }}"/></td>
+        <td class="emailinp"><input name="speaker_email{{i}}" value="{{ talk.speaker_email | blanknone }}" maxlength="{{ maxlength['email'] }}"/></td>
+        <td class="affiliationinp"><input name="speaker_affiliation{{i}}" value="{{ talk.speaker_affiliation | blanknone }}" maxlength="{{ maxlength['affiliation'] }}"/></td>
+        <td class="titleinp"><input name="title{{i}}" value="{{ talk.title | blanknone }}" maxlength="{{ maxlength['title'] }}"/></td>
         <td align="left" style="padding-right:0px;"><input type="checkbox" name="hidden{{i}}" value="yes"{% if talk.hidden %} checked {% endif %} /></td>
         <td align="left">{{ talk.details_link() | safe }}</td>
         <input type="hidden" name="seminar_ctr{{i}}" value="{{ talk.seminar_ctr }}" />
       {% else %}
-        <td class="speakerinp"><input name="speaker{{i}}" value="" /></td>
-        <td class="emailinp"><input name="speaker_email{{i}}" value="" /></td>
-        <td class="affiliationinp"><input name="speaker_affiliation{{i}}" value="" /></td>
-        <td class="titleinp"><input name="title{{i}}" value="" /></td>
+        <td class="speakerinp"><input name="speaker{{i}}" value="" maxlength="{{ maxlength['speaker'] }}"/></td>
+        <td class="emailinp"><input name="speaker_email{{i}}" value="" maxlength="{{ maxlength['email'] }}"/></td>
+        <td class="affiliationinp"><input name="speaker_affiliation{{i}}" value="" maxlength="{{ maxlength['affiliation'] }}"/></td>
+        <td class="titleinp"><input name="title{{i}}" value="" maxlength="{{ maxlength['title'] }}"/></td>
         <td><input type="checkbox" name="hidden{{i}}" value="yes"/></td>
         <input type="hidden" name="seminar_ctr{{i}}" value="" />
       {% endif %}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -22,26 +22,26 @@
     <table>
     <tr>
       <td style="width:150px">{{ KNOWL("speaker") }}</td>
-      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" placeholder="Firstname Lastname"/></td>
+      <td><input name="speaker" value="{{ talk.speaker | blanknone }}" style="width:600px;" maxlength="{{ maxlength['speaker'] }}" placeholder="Firstname Lastname"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_email") }}</td>
-      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" placeholder="someone@upan.edu"/></td>
+      <td><input name="speaker_email" value="{{ talk.speaker_email | blanknone }}" style="width:600px;" maxlength="{{ maxlength['speaker_email'] }}" placeholder="someone@upan.edu"/></td>
       <td class="forminfo" />Visible only to organizers.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_affiliation") }}</td>
-      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" placeholder="University of Pangaea" /></td>
+      <td><input name="speaker_affiliation" value="{{ talk.speaker_affiliation | blanknone }}" style="width:600px;" maxlength="{{ maxlength['speaker_affiliation'] }}" placeholder="University of Pangaea" /></td>
     </tr>
     <tr>
       <td>{{ KNOWL("speaker_homepage") }}</td>
-      <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" placeholder="https://upan.edu/~someone"/></td>
+      <td><input name="speaker_homepage" value="{{ talk.speaker_homepage | blanknone }}" style="width:600px;" maxlength="{{ maxlength['speaker_homepage'] }}"placeholder="https://upan.edu/~someone"/></td>
       <td class="forminfo" />Please set if available.</td>
     </tr>
     <tr>
       <td>{{ KNOWL("title") }}</td>
-      <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" placeholder="TeX symbols are OK here" /></td>
-      <td class="forminfo" />Capitalize only the first word and proper nouns.</td>
+      <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" maxlength="{{ maxlength['title'] }}" placeholder="TeX symbols are OK here" /></td>
+      <td class="forminfo" />Capitalize first word and proper nouns only. Leave blank if TBA.</td>
     </tr>
     {% if topdomain != "mathseminars.org" %} {# FIXME: temporary measure during addition of physics #}
     <tr>
@@ -64,11 +64,11 @@
     </tr>
     <tr>
       <td>{{ KNOWL("paper_link") }}</td>
-      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:600px;" placeholder="https://arxiv.org/abs/9999.99999"/></td>
+      <td><input name="paper_link" value="{{ talk.paper_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['paper_link'] }}" placeholder="https://arxiv.org/abs/9999.99999"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("slide_link") }}</td>
-      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:600px;" placeholder="https://upan.edu/~someone/myslides.pdf"/></td>
+      <td><input name="slides_link" value="{{ talk.slides_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['slides_link'] }}"placeholder="https://upan.edu/~someone/myslides.pdf"/></td>
     </tr>
   <tr>
     <td>{{ KNOWL("abstract") }}</td>
@@ -77,7 +77,7 @@
   <table>
     <tr>
       <td colspan="2">
-        <textarea cols="89" rows="10" style="width:770px;"  name="abstract" id="inp_abstract" placeholder="TeX symbols are OK here.  This is joint work with Leonhard Euler.">{{talk.abstract | blanknone }}</textarea>
+        <textarea cols="89" rows="10" style="width:770px;"  name="abstract" id="inp_abstract" maxlength="{{ maxlength['abstract'] }}" placeholder="TeX symbols are OK here.  This is joint work with Leonhard Euler.">{{talk.abstract | blanknone }}</textarea>
       </td>
     </tr>
   </table>
@@ -167,11 +167,11 @@
     </tr>
     <tr>
       <td>{{ KNOWL("room") }}</td>
-      <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" placeholder="Room 2-190 in the Simons building" /></td>
+      <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" maxlength="{{ maxlength['room'] }}" placeholder="Room 2-190 in the Simons building" /></td>
     </tr>
     <tr>
       <td>{{ KNOWL("live_link") }}</td>
-      <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
+      <td><input name="live_link" value="{{ talk.live_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['live_link'] }}" placeholder="e.g., https://zoom.us/j/1234 or https://www.youtube.com/watch?v=1234"/></td>
     </tr>
     <tr>
       <td>{{ KNOWL("access") }}</td>
@@ -185,13 +185,13 @@
     </tr>
      <tr>
       <td>{{ KNOWL("video_link") }}</td>
-      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" placeholder="https://www.youtube.com/watch?v=abc123"></td>
+      <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['video_link'] }}"placeholder="https://www.youtube.com/watch?v=abc123"></td>
     </tr>
     {% else %}
     {# attributes non-organizers cannot edit #}
     <input type="hidden" name="hidden" value="{{ 'yes' if talk.hidden else 'no' }}" />
-    <input type="hidden" name="room" value="{{ talk.room | blanknone }}" />
-    <input type="hidden" name="live_link" value="{{ talk.live_link | blanknone }}" />
+    <input type="hidden" name="room" value="{{ talk.room | blanknone }}" maxlength="{{ maxlength['room'] }}" />
+    <input type="hidden" name="live_link" value="{{ talk.live_link | blanknone }}" maxlength="{{ maxlength['live_link'] }}" />
     <input type="hidden" name="access" value="{{ talk.access }}" />
     {# attributes non-organizers can edit #}
     {% if talk.room %}
@@ -214,7 +214,7 @@
       <td colspan="2">{{ KNOWL("talk_comments") }}</td>
     </tr>
     <tr>
-      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" placeholder="Talk-specific livestream access instructions?  Notes about the speaker?  HTML and $\TeX$ are OK here.  Both the talk comments and the series comments below will appear on the talk's page.">{{ talk.comments | blanknone }}</textarea></td>
+      <td colspan="2"><textarea cols="89" rows="4" style="width:770px;" name="comments" maxlength="{{ maxlength['comments'] }}" placeholder="Talk-specific livestream access instructions?  Notes about the speaker?  HTML and $\TeX$ are OK here.  Both the talk comments and the series comments below will appear on the talk's page.">{{ talk.comments | blanknone }}</textarea></td>
     </tr>
 </table>
 <br>

--- a/seminars/create/templates/show_similar.html
+++ b/seminars/create/templates/show_similar.html
@@ -32,7 +32,6 @@
     <tr>
       <td><button type="submit">Continue</button></td>
       <td><button type="submit" formmethod="get" formaction="{{ url_for('create.index') }}">Cancel</button></td>
-      <!--<td><a style="margin-left: 30px" onclick="unsaved = false;" href="{{ url_for('create.index') }}">Cancel creation</a>-->
     </tr>
   </table>
 

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -670,6 +670,7 @@ def list_institutions():
         section=section,
         subsection="institutions",
         institutions=institutions(),
+        maxlength=maxlength
     )
 
 

--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -155,7 +155,7 @@
           </div>
           {% if user.is_admin or user.email == institution.admin %}
             <div class="submenu-nav{% if subsection == 'editinst' %} submenu-active{% endif %}">
-              <a href="{{ url_for('create.edit_institution', shortname=institution.shortname) }}">Edit series</a>
+              <a href="{{ url_for('create.edit_institution', shortname=institution.shortname) }}">Edit institution</a>
             </div>
           {% endif %} {# institution admin #}
         {% elif seminar and seminar.user_can_edit() %}

--- a/seminars/templates/institutions.html
+++ b/seminars/templates/institutions.html
@@ -13,12 +13,12 @@
   <table id="make_inst">
     <tr>
       <td>{{ ASTKNOWL("institution_name") }}</td>
-      <td><input name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="64"/></td>
+      <td><input name="name" style="width:500px;" placeholder="University of Pangaea" maxlength="{{ maxlength['institutions.name'] }}"/></td>
       <td class="forminfo"><p style="width:230px;">Click blue captions for more details. Asterisks denote required items.</p></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("institution_shortname") }}</td>
-      <td><input name="shortname" style="width:500px;" placeholder="UPan" maxlength="32"/></td>
+      <td><input name="shortname" style="width:500px;" placeholder="UPan" maxlength="{{ maxlength['shortname'] }}"/></td>
       <td class="forminfo">Use 2-32 characters, no spaces.
     </tr>
     <tr>

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -24,6 +24,45 @@ short_weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 daytime_re_string = r'\d{1,4}|\d{1,2}:\d\d|'
 daytime_re = re.compile(daytime_re_string)
 
+# Bounds on input field lengths
+MAX_SHORTNAME_LEN = 32
+MAX_DESCRIPTION_LEN = 64
+MAX_NAME_LEN = 128
+MAX_TITLE_LEN = 256
+MAX_EMAIL_LEN = 256
+MAX_URL_LEN = 1024
+MAX_TEXT_LEN = 65536
+MAX_SLOTS = 12 # Must be a multiple of 3
+MAX_SPEAKERS = 8 
+MAX_ORGANIZERS = 10
+
+maxlength = {
+    'abstract' : MAX_TEXT_LEN,
+    'aliases' : MAX_NAME_LEN,
+    'city' : MAX_NAME_LEN,
+    'comments' : MAX_TEXT_LEN,
+    'description' : MAX_
+    'full_name' : MAX_NAME_LEN, # FIXME we should really rename this column to name
+    'homepage' : MAX_URL_LEN,
+    'live_link' : MAX_URL_LEN,
+    'name' : MAX_NAME_LEN,
+    'organizers' : MAX_ORGANIZERS,
+    'paper_link' : MAX_URL_LEN,
+    'room' : MAX_NAME_LEN,
+    'shortname' : MAX_SHORTNAME_LEN,
+    'slides_link' : MAX_URL_LEN,
+    'speaker': 8*MAX_NAME_LEN, # FIXME once multiple speakers are properly supported
+    'speakers' : MAX_SPEAKERS,
+    'speaker_affliation': 8*MAX_NAME_LEN, # FIXME once multiple speakers are properly supported
+    'speaker_email': MAX_EMAIL_LEN,
+    'speaker_homepage': MAX_URL_LEN,
+    'stream_link' : MAX_URL_LEN,
+    'time_slots' : MAX_SLOTS,
+    'title' : MAX_TITLE_LEN,
+    'video_link' : MAX_URL_LEN,
+    'weekdays' : MAX_SLOTS,
+}
+
 def topdomain():
     # return 'mathseminars.org'
     # return 'researchseminars.org'
@@ -468,7 +507,9 @@ def process_user_input(inp, col, typ, tz):
         inp = inp.strip()
     if not inp:
         return False if typ == "boolean" else ("" if typ == "text" else None)
-    elif typ == "time":
+    if col in maxlength and len(inp) > maxlength[col]:
+        raise ValueError("Input exceeds maximum length permitted")
+    if typ == "time":
         # Note that parse_time, when passed a time with no date, returns
         # a datetime object with the date set to today.  This could cause different
         # relative orders around daylight savings time, so we store all times

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -41,7 +41,7 @@ maxlength = {
     'aliases' : MAX_NAME_LEN,
     'city' : MAX_NAME_LEN,
     'comments' : MAX_TEXT_LEN,
-    'description' : MAX_
+    'description' : MAX_DESCRIPTION_LEN,
     'full_name' : MAX_NAME_LEN, # FIXME we should really rename this column to name
     'homepage' : MAX_URL_LEN,
     'live_link' : MAX_URL_LEN,

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -27,11 +27,11 @@ daytime_re = re.compile(daytime_re_string)
 # Bounds on input field lengths
 MAX_SHORTNAME_LEN = 32
 MAX_DESCRIPTION_LEN = 64
-MAX_NAME_LEN = 128
+MAX_NAME_LEN = 100
 MAX_TITLE_LEN = 256
 MAX_EMAIL_LEN = 256
-MAX_URL_LEN = 1024
-MAX_TEXT_LEN = 65536
+MAX_URL_LEN = 256
+MAX_TEXT_LEN = 8192
 MAX_SLOTS = 12 # Must be a multiple of 3
 MAX_SPEAKERS = 8 
 MAX_ORGANIZERS = 10
@@ -44,6 +44,7 @@ maxlength = {
     'description' : MAX_DESCRIPTION_LEN,
     'full_name' : MAX_NAME_LEN, # FIXME we should really rename this column to name
     'homepage' : MAX_URL_LEN,
+    'institutions.name' : MAX_DESCRIPTION_LEN,
     'live_link' : MAX_URL_LEN,
     'name' : MAX_NAME_LEN,
     'organizers' : MAX_ORGANIZERS,
@@ -53,7 +54,7 @@ maxlength = {
     'slides_link' : MAX_URL_LEN,
     'speaker': 8*MAX_NAME_LEN, # FIXME once multiple speakers are properly supported
     'speakers' : MAX_SPEAKERS,
-    'speaker_affliation': 8*MAX_NAME_LEN, # FIXME once multiple speakers are properly supported
+    'speaker_affiliation': 8*MAX_NAME_LEN, # FIXME once multiple speakers are properly supported
     'speaker_email': MAX_EMAIL_LEN,
     'speaker_homepage': MAX_URL_LEN,
     'stream_link' : MAX_URL_LEN,


### PR DESCRIPTION
Adds max length parameters for all text input fields to utils.py that are used both in input forms and when processing user input (so will catch input typed directly into a URL).

Also fixes a bug in the editinst menu (Edit series changed to Edit Institution) and makes it impossible to create two institutions with the exact same name (which would be very confusing in the institution selector.  Of course institutions with the same name do exist in the real world -- users are told to include disambiguating information in the name field in this case.