### PR TITLE
researchseminars email and endorsement/support groups

### DIFF
--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -628,7 +628,7 @@ def _search_series(conference):
     subsection = "conferences" if conference else "seminars"
     title = "Search " + ("conferences" if conference else "seminar series")
     return render_template(
-        "search_seminars.html", title=title, info=info, section="Search",subsection=subsection, bread=None, is_conference=conference
+        "search_seminars.html", title=title, info=info, section="Search", subsection=subsection, bread=None, is_conference=conference
     )
 
 @app.route("/search/talks")

--- a/seminars/templates/contact.html
+++ b/seminars/templates/contact.html
@@ -30,13 +30,13 @@
   <li>
     <p>
     <b>Want to help improve the site yourself?</b> 
-          <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>.
+          <a href="mailto:researchseminars@math.mit.edu" target="_blank">Send an email</a>.
     </p>
   </li>
    <li>
     <p>
     <b>Want to add a whole new subject to the site?</b> 
-          <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>.
+          <a href="mailto:researchseminars@math.mit.edu" target="_blank">Send an email</a>.
     </p>
   </li>
   </ul>

--- a/seminars/templates/contact.html
+++ b/seminars/templates/contact.html
@@ -16,8 +16,8 @@
   <li>
     <p>
       <b>Urgent question or error report?</b> 
-    <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>
-  to the <a href="https://groups.google.com/forum/#!forum/mathseminars-dev"
+    <a href="mailto:researchseminars-support@googlegroups.com" target="_blank">Send an email</a>
+  to the <a href="https://groups.google.com/forum/#!forum/researchseminars-support"
                         target="_blank">developers' mailing list</a>.
      </p>
   </li>
@@ -30,13 +30,13 @@
   <li>
     <p>
     <b>Want to help improve the site yourself?</b> 
-          <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>.
+          <a href="mailto:researchseminars-support@googlegroups.com" target="_blank">Send an email</a>.
     </p>
   </li>
    <li>
     <p>
     <b>Want to add a whole new subject to the site?</b> 
-          <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>.
+          <a href="mailto:researchseminars-support@googlegroups.com" target="_blank">Send an email</a>.
     </p>
   </li>
   </ul>

--- a/seminars/templates/contact.html
+++ b/seminars/templates/contact.html
@@ -30,13 +30,13 @@
   <li>
     <p>
     <b>Want to help improve the site yourself?</b> 
-          <a href="mailto:researchseminars-support@googlegroups.com" target="_blank">Send an email</a>.
+          <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>.
     </p>
   </li>
    <li>
     <p>
     <b>Want to add a whole new subject to the site?</b> 
-          <a href="mailto:researchseminars-support@googlegroups.com" target="_blank">Send an email</a>.
+          <a href="mailto:mathseminars-dev@googlegroups.com" target="_blank">Send an email</a>.
     </p>
   </li>
   </ul>

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -344,7 +344,7 @@ def send_confirmation_email(email):
         import sys
 
         flash_error(
-            'Unable to send email confirmation link, please contact <a href="mailto:mathseminars@math.mit.edu">mathseminars@math.mit.edu</a> directly to confirm your email'
+            'Unable to send email confirmation link, please contact <a href="mailto:researchseminars@math.mit.edu">researchseminars@math.mit.edu</a> directly to confirm your email'
         )
         app.logger.error("%s unable to send email to %s due to error: %s" % (timestamp(), email, sys.exc_info()[0]))
         return False

--- a/seminars/users/pwdmanager.py
+++ b/seminars/users/pwdmanager.py
@@ -170,8 +170,8 @@ class PostgresUserTable(PostgresSearchTable):
         email = data["email"]
         with DelayCommit(db):
             # We probably have code that assumes that admin/owner isn't None....
-            db.institutions.update({"admin": ilike_query(email)}, {"admin": "mathseminars-dev@googlegroups.com"})
-            db.seminars.update({"owner": ilike_query(email)}, {"owner": "mathseminars-dev@googlegroups.com"})
+            db.institutions.update({"admin": ilike_query(email)}, {"admin": "researchseminars@math.mit.edu"})
+            db.seminars.update({"owner": ilike_query(email)}, {"owner": "researchseminars@math.mit.edu"})
             db.seminar_organizers.delete({"email": ilike_query(email)})
             db.talks.update({"speaker_email": ilike_query(email)}, {"speaker_email": ""})
             self.update({"id": uid}, {key: None for key in self.search_cols}, restat=False)

--- a/seminars/users/templates/public_users.html
+++ b/seminars/users/templates/public_users.html
@@ -6,7 +6,7 @@
   If you are seeking to be endorsed so that you can create seminars, please find someone you know in the second column below, and manually contact them to ask them to visit their Account page to endorse you.  Make sure to tell them which email address to endorse!
 </p>
 <p>
-  Alternatively, you may request endorsement by emailing <a href="mailto:mathseminars-dev@googlegroups.com">mathseminars-dev@googlegroups.com</a>; include a link to something containing your email address (a page at your institution, an arXiv preprint you posted, or a published paper, say), so that we can be sure it is really you! 
+  Alternatively, you may request endorsement by emailing <a href="mailto:researchseminars-endorsement@googlegroups.com">researchseminars-endorsement@googlegroups.com</a>; include a link to something containing your email address (a page at your institution, an arXiv preprint you posted, or a published paper, say), so that we can be sure it is really you! 
 </p>
 
 <table>


### PR DESCRIPTION
Updates email addresses and google groups from mathseminars to researchseminars.

@edgarcosta and @roed314  can one of you sanity check these changes (and make sure I didn't miss any)?