### PR TITLE
Resolves #441

### DIFF
--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -694,7 +694,7 @@ def next_talk_sorted(results):
     Returns the sorted list.
     """
     results = list(results)
-    ntdict = next_talks({'visibility':{'$eq':2}})  # only count visible talks when sorting
+    ntdict = next_talks({'hidden':False})  # ignore hidden talks for sorting purposes
     for R in results:
         R.next_talk_time = ntdict[R.shortname]
     results.sort(key=lambda R: (R.next_talk_time, R.name))

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -694,7 +694,7 @@ def next_talk_sorted(results):
     Returns the sorted list.
     """
     results = list(results)
-    ntdict = next_talks({'visibility':{'$eq'2}})  # only count visible talks when sorting
+    ntdict = next_talks({'visibility':{'$eq':2}})  # only count visible talks when sorting
     for R in results:
         R.next_talk_time = ntdict[R.shortname]
     results.sort(key=lambda R: (R.next_talk_time, R.name))

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -694,7 +694,7 @@ def next_talk_sorted(results):
     Returns the sorted list.
     """
     results = list(results)
-    ntdict = next_talks()
+    ntdict = next_talks({'visibility':{'$eq'2}})  # only count visible talks when sorting
     for R in results:
         R.next_talk_time = ntdict[R.shortname]
     results.sort(key=lambda R: (R.next_talk_time, R.name))

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -669,7 +669,7 @@ def next_talks(query=None):
     A dictionary with keys the seminar_ids and values datetimes (either the next talk in that seminar, or datetime.max if no talk scheduled so that they sort at the end.
     """
     if query is None:
-        query = {"end_time": {"$gte": datetime.now(pytz.UTC)}}
+        query = {"end_time": {"$gte": datetime.now(pytz.UTC)}, "hidden": False}  # ignore hidden talks by default
     ans = defaultdict(lambda: pytz.UTC.localize(datetime.max))
     from seminars.talk import _counter as talks_counter
     _selecter = SQL("""
@@ -694,7 +694,7 @@ def next_talk_sorted(results):
     Returns the sorted list.
     """
     results = list(results)
-    ntdict = next_talks({'hidden':False})  # ignore hidden talks for sorting purposes
+    ntdict = next_talks()
     for R in results:
         R.next_talk_time = ntdict[R.shortname]
     results.sort(key=lambda R: (R.next_talk_time, R.name))

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -85,6 +85,7 @@ class WebTalk(object):
             if data.get("topics"):
                 data["topics"] = [(topic if "_" in topic else "math_" + topic) for topic in data["topics"]]
             self.__dict__.update(data)
+        self.cleanse()
 
     def __repr__(self):
         title = self.title if self.title else "TBA"
@@ -103,6 +104,14 @@ class WebTalk(object):
 
     def __ne__(self, other):
         return not (self == other)
+
+    def cleanse(self):
+        """
+        This functon is used to ensure backward compatibility across changes to the schema and/or validation
+        This is the only place where columns we plan to drop should be referenced 
+        """
+        if self.hidden is None:
+            self.hidden = False
 
     def visible(self):
         """


### PR DESCRIPTION
next_talks now includes hidden:False in the default query (but it won't force it if a query is specified, currently this is not done anywhere in the code, next_talk_sorted is the only place where next_talks is called).

I set hidden to false for the 180 or so old talks in the database that had hidden set to None (going forward it should always be set to True or False).
