### PR TITLE
Two click delete and permdelete

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -238,7 +238,6 @@ def delete_seminar(shortname):
         return failure()
 
     raw_data = request.form if request.method == "POST" else {}
-    permdelete = False
     if seminar.deleted:
         if raw_data.get("submit") == "revive":
             return redirect(url_for(".revive_seminar", shortname=shortname), 302)
@@ -267,7 +266,6 @@ def delete_seminar(shortname):
         talks=talks,
         title="Delete series",
         section="Manage",
-        permdelete=permdelete,
     )
 
 
@@ -350,12 +348,10 @@ def delete_talk(seminar_id, seminar_ctr):
         return failure()
 
     raw_data = request.form if request.method == "POST" else {}
-    permdelete = False
+
     if talk.deleted:
         if raw_data.get("submit") == "revive":
             return redirect(url_for(".revive_talk", seminar_id=seminar_id, seminar_ctr=seminar_ctr), 302)
-        if raw_data.get("submit") == "delete":
-            permdelete = True
         if raw_data.get("submit") == "permdelete":
             return redirect(url_for(".permdelete_talk", seminar_id=seminar_id, seminar_ctr=seminar_ctr), 302)
     else:
@@ -363,10 +359,13 @@ def delete_talk(seminar_id, seminar_ctr):
             return redirect(url_for(".edit_talk", seminar_id=seminar_id, seminar_ctr=seminar_ctr), 302)
         if raw_data.get("submit") == "delete":
             if talk.delete():
-                flash("Talk deleted")
+                flash("Talk deleted.")
             else:
-                flash_error("Only the organizers of a seminar can delete talks in it")
+                flash_error("You do not have permission to delete this talk.")
                 return failure()
+        if raw_data.get("submit") == "permdelete":
+            return redirect(url_for(".permdelete_talk", seminar_id=seminar_id, seminar_ctr=seminar_ctr), 302)
+
     return render_template(
         "deleted_talk.html",
         seminar_id=seminar_id,
@@ -375,7 +374,6 @@ def delete_talk(seminar_id, seminar_ctr):
         talk=talk,
         title="Delete talk",
         section="Manage",
-        permdelete=permdelete,
     )
 
 

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -7,14 +7,10 @@
 
 <form action="{{ url_for('.delete_seminar',  shortname=shortname) }}" method="POST">
 {% if seminar.deleted %}
-    {% if permdelete %}
-        <p><b>Are you sure you want to do this?</b> A permanently deleted {{seminar.series_type}} cannot be restored.</p>
-    {% else %}
-        <p>The {{seminar.series_type}} below and all its talks have been deleted.  You can restore them later if needed, but users will have to resubscribe to add them to their favorites.</p>
-    {% endif %}
+     <p>The {{seminar.series_type}} below and all its talks have been deleted.  You can restore them or permanently delete them.</p>
 {% else %}
-    <p>Deleting the {{seminar.series_type}} below will delete all the talks it contains, and cancel any subscriptions.
-    You can restore the {{seminar.series_type}} and its talks later, but subscriptions will not be restored.</p>
+    <p>Deleting the {{seminar.series_type}} below will cancel any subscriptions and ensure that the {{seminar.series_type}} and its associated talks are no longer visible on this site.  You will be able to restore them later if needed from the Manage series page (subscriptions will not be restored).</p>
+    <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database. This operation <b>cannot be undone</b>.
 {% endif %}
 <table>
 <tr>{{ series_header(include_subscribe=False) | safe }}</tr>
@@ -23,16 +19,12 @@
 <br>
 <table><tr>
 {% if seminar.deleted %}
-    {% if permdelete %}
-        <td><button class="savedelete" type="submit" name="submit" value="permdelete">Permanently delete seminar</button></td>
-        <td><button class="cancel" type="submit" name="submit" value="cancel">Cancel permanent deletion</button></td>
-    {% else %}
         <td><button class="save" type="submit" name="submit" value="revive">Revive series</button></td>
-        <td><button class="delete" type="submit" name="submit" value="delete">Permanently delete seminar</button></td>
-    {% endif %}
+        <td><button class="savedelete" type="submit" name="submit" value="permdelete">Permanently delete series</button></td>
 {% else %}
-    <td><button class="savedelete" type="sumbit" name="submit" value="delete">Delete series</button></td>
     <td><button class="cancel" type="sumbit" name="submit" value="cancel">Cancel deletion</button></td>
+    <td><button class="savedelete" type="sumbit" name="submit" value="delete">Delete series</button></td>
+    <td><button class="delete" type="submit" name="submit" value="permdelete">Permanently delete series</button></td>
 {% endif %}
 </tr></table>
 {% if talks %}

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -9,11 +9,11 @@
 {% if seminar.deleted %}
      <p>The {{seminar.series_type}} below and all its talks have been deleted.  You can restore them or permanently delete them.</p>
 {% else %}
-    <p>Deleting the {{seminar.series_type}} listed below will cancel all subscriptions and ensure that it is not visible on this site.
+    <p>Deleting the {{seminar.series_type}} listed below will cancel all subscriptions and ensure that it is not visible on this site.<br>
     {% if talks %} The same applies to all of its associated talks, which are listed below.{% endif %}
-    You will be able to restore the {{seminar.series_type}} and any associated talks later from the Manage series page (subscriptions will not be restored).</p>
+    You can restore the {{seminar.series_type}} and any associated talks later from the Manage series page (but subscriptions will not be restored).</p>
     <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database.<br>
-    <b>This operation cannot be undone</b>.
+    <b>Permanent deletion cannot be undone</b>.
     </p>
 {% endif %}
 <table>

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -11,7 +11,7 @@
 {% else %}
     <p>Deleting the {{seminar.series_type}} listed below will cancel all subscriptions and ensure that it is not visible on this site.<br>
     {% if talks %} The same applies to all of its associated talks, which are listed below.{% endif %}
-    You will be able to restore the {{seminar.series_type}} and any associated talks later from the Manage series page (but subscriptions will not be restored).</p>
+    You will be able to restore the {{seminar.series_type}} and any associated talks later if needed, but subscriptions will not be restored.</p>
     <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database.<br>
     <b>This cannot be undone</b>.
     </p>

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -10,7 +10,9 @@
      <p>The {{seminar.series_type}} below and all its talks have been deleted.  You can restore them or permanently delete them.</p>
 {% else %}
     <p>Deleting the {{seminar.series_type}} below will cancel any subscriptions and ensure that the {{seminar.series_type}} and its associated talks are no longer visible on this site.  You will be able to restore them later if needed from the Manage series page (subscriptions will not be restored).</p>
-    <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database. This operation <b>cannot be undone</b>.
+    <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database.<br>
+    <b>This operation <b>cannot be undone</b>.
+    </p>
 {% endif %}
 <table>
 <tr>{{ series_header(include_subscribe=False) | safe }}</tr>
@@ -24,7 +26,7 @@
 {% else %}
     <td><button class="cancel" type="sumbit" name="submit" value="cancel">Cancel deletion</button></td>
     <td><button class="savedelete" type="sumbit" name="submit" value="delete">Delete series</button></td>
-    <td><button class="delete" type="submit" name="submit" value="permdelete">Permanently delete series</button></td>
+    <td><button class="savedelete" type="submit" name="submit" value="permdelete">Permanently delete series</button></td>
 {% endif %}
 </tr></table>
 {% if talks %}

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -11,9 +11,9 @@
 {% else %}
     <p>Deleting the {{seminar.series_type}} listed below will cancel all subscriptions and ensure that it is not visible on this site.<br>
     {% if talks %} The same applies to all of its associated talks, which are listed below.{% endif %}
-    You can restore the {{seminar.series_type}} and any associated talks later from the Manage series page (but subscriptions will not be restored).</p>
+    You will be able to restore the {{seminar.series_type}} and any associated talks later from the Manage series page (but subscriptions will not be restored).</p>
     <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database.<br>
-    <b>Permanent deletion cannot be undone</b>.
+    <b>This cannot be undone</b>.
     </p>
 {% endif %}
 <table>

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -9,7 +9,9 @@
 {% if seminar.deleted %}
      <p>The {{seminar.series_type}} below and all its talks have been deleted.  You can restore them or permanently delete them.</p>
 {% else %}
-    <p>Deleting the {{seminar.series_type}} below will cancel any subscriptions and ensure that the {{seminar.series_type}} and its associated talks are no longer visible on this site.  You will be able to restore them later if needed from the Manage series page (subscriptions will not be restored).</p>
+    <p>Deleting the {{seminar.series_type}} listed below will cancel all subscriptions and ensure that it is not visible on this site.
+    {% if talks %} The same applies to all of its associated talks, which are listed below.{% endif %}
+    You will be able to restore the {{seminar.series_type}} and any associated talks later from the Manage series page (subscriptions will not be restored).</p>
     <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database.<br>
     <b>This operation <b>cannot be undone</b>.
     </p>

--- a/seminars/templates/deleted_seminar.html
+++ b/seminars/templates/deleted_seminar.html
@@ -13,7 +13,7 @@
     {% if talks %} The same applies to all of its associated talks, which are listed below.{% endif %}
     You will be able to restore the {{seminar.series_type}} and any associated talks later from the Manage series page (subscriptions will not be restored).</p>
     <p>Permanent deletion removes all information related to the {{seminar.series_type}} and its associated talks from our database.<br>
-    <b>This operation <b>cannot be undone</b>.
+    <b>This operation cannot be undone</b>.
     </p>
 {% endif %}
 <table>

--- a/seminars/templates/deleted_talk.html
+++ b/seminars/templates/deleted_talk.html
@@ -4,14 +4,15 @@
 
 <form action="{{ url_for('.delete_talk',  seminar_id=seminar_id, seminar_ctr=seminar_ctr) }}" method="POST">
 {% if talk.deleted %}
-    {% if permdelete %}
-        <p><b>Are you sure you want to do this?</b> Permanently deleted talks cannot be restored.</p>
-    {% else %}
-        <p>The talk below has been deleted.</p>
-    {% endif %}
+     <p>The talk below and all its talks have been deleted.  You can restore it or permanently delete it.</p>
 {% else %}
-    <p>Deleting the talk below will cancel any subscriptions to it.   You can restore the talk later, but subscriptions will not be restored.</p>
+    <p>Deleting the talk listed below will cancel all subscriptions and ensure that it is not visible on this site.
+    You will be able to restore the talk later from the Manage series page (subscriptions will not be restored).</p>
+    <p>Permanent deletion removes all information related to talk from our database.<br>
+    <b>This operation cannot be undone</b>.
+    </p>
 {% endif %}
+
 <table>
 <tr>{{ talks_header(include_subscribe=False) | safe }}</tr>
 <tr>{{ talk.oneline(include_subscribe=False) | safe }}</tr>
@@ -19,16 +20,12 @@
 <br>
 <table><tr>
 {% if talk.deleted %}
-    {% if permdelete %}
-        <td><button class="savedelete" type="submit" name="submit" value="permdelete">Permanently delete talk</button></td>
-        <td><button class="cancel" type="submit" name="submit" value="cancel">Cancel permanent deletion</button></td>
-    {% else %}
         <td><button class="save" type="submit" name="submit" value="revive">Revive talk</button></td>
-        <td><button class="delete" type="submit" name="submit" value="delete">Permanently delete talk</button></td>
-    {% endif %}
+        <td><button class="savedelete" type="submit" name="submit" value="permdelete">Permanently delete talk</button></td>
 {% else %}
-    <td><button class="savedelete" type="sumbit" name="submit" value="delete">Delete talk</button></td>
     <td><button class="cancel" type="sumbit" name="submit" value="cancel">Cancel deletion</button></td>
+    <td><button class="savedelete" type="sumbit" name="submit" value="delete">Delete talk</button></td>
+    <td><button class="savedelete" type="submit" name="submit" value="permdelete">Permanently delete talk</button></td>
 {% endif %}
 </tr></table>
 </form>

--- a/seminars/templates/deleted_talk.html
+++ b/seminars/templates/deleted_talk.html
@@ -7,7 +7,7 @@
      <p>The talk below and all its talks have been deleted.  You can restore it or permanently delete it.</p>
 {% else %}
     <p>Deleting the talk below will cancel all subscriptions and ensure that the talk is not visible on this site.<br>
-    You can restore the talk later from the Manage series page (but subscriptions will not be restored).</p>
+    You will be able to restore the talk later if needed, but subscriptions will not be restored.</p>
     <p>Permanent deletion will remove all information related to this talk from our database.<br>
     <b>This cannot be undone</b>.
     </p>

--- a/seminars/templates/deleted_talk.html
+++ b/seminars/templates/deleted_talk.html
@@ -6,10 +6,10 @@
 {% if talk.deleted %}
      <p>The talk below and all its talks have been deleted.  You can restore it or permanently delete it.</p>
 {% else %}
-    <p>Deleting the talk listed below will cancel all subscriptions and ensure that it is not visible on this site.
-    You will be able to restore the talk later from the Manage series page (subscriptions will not be restored).</p>
-    <p>Permanent deletion removes all information related to talk from our database.<br>
-    <b>This operation cannot be undone</b>.
+    <p>Deleting the talk below will cancel all subscriptions and ensure that the talk is not visible on this site.<br>
+    You can restore the talk later from the Manage series page (but subscriptions will not be restored).</p>
+    <p>Permanent deletion will remove all information related to this talk from our database.<br>
+    <b>Permanent deletion cannot be undone</b>.
     </p>
 {% endif %}
 

--- a/seminars/templates/deleted_talk.html
+++ b/seminars/templates/deleted_talk.html
@@ -9,7 +9,7 @@
     <p>Deleting the talk below will cancel all subscriptions and ensure that the talk is not visible on this site.<br>
     You can restore the talk later from the Manage series page (but subscriptions will not be restored).</p>
     <p>Permanent deletion will remove all information related to this talk from our database.<br>
-    <b>Permanent deletion cannot be undone</b>.
+    <b>This cannot be undone</b>.
     </p>
 {% endif %}
 


### PR DESCRIPTION
You can now delete or permanently delete any series or talk in two clicks (both options are presented on the Delete talk/series page, as suggested by @poonen).