### PR TITLE
Handle unicode dash variants in times, fix slot display on back button

### DIFF
--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -276,54 +276,6 @@ const subjOptions = [
   {% endfor %}
 ];
 
-function showplusminus(n) {
-  document.getElementById('slotminus').style.visibility = ( n > 1 ? 'visible' : 'hidden' );
-  document.getElementById('slotplus').style.visibility = ( n < {{ maxlength["time_slots"] }} ? 'visible' : 'hidden' );
-}
-$("a.slotplus").click(function(e){
-  e.preventDefault();
-  var n = parseInt(document.getElementById('slots').value)+1;
-  document.getElementById('slots').value = '' + n;
-  if ( n <= 3 ) {
-    document.getElementById('weekday'+(n-1)).style.visibility = 'visible';
-    document.getElementById('time_slot'+(n-1)).style.visibility = 'visible';
-  } else {
-    document.getElementById('weekday'+(n-1)).style.display = 'block';
-    document.getElementById('time_slot'+(n-1)).style.display = 'block';
-  }
-  showplusminus(n);
-});
-$("a.slotminus").click(function(e){
-  e.preventDefault();
-  var n = parseInt(document.getElementById('slots').value)-1;
-  document.getElementById('slots').value = '' + n;
-  document.getElementById('weekday'+n).value = '';
-  document.getElementById('time_slot'+n).value ='';
-  if ( n < 3 ) {
-    document.getElementById('weekday'+n).style.visibility = 'hidden';
-    document.getElementById('time_slot'+n).style.visibility = 'hidden';
-  } else {
-    document.getElementById('weekday'+n).style.display = 'none';
-    document.getElementById('time_slot'+n).style.display = 'none';
-  }
-  showplusminus(n);
-});
-function showslots() {
-  var n = parseInt(document.getElementById('slots').value);
-  if ( n <= 0 ) document.getElementById('slots').value = '' + (n=1);
-  for ( var i = 0 ; i < n ; i++ ) {
-    if ( i < 3 ) {
-      document.getElementById('weekday'+i).style.visibility = 'visible';
-      document.getElementById('time_slot'+i).style.visibility = 'visible';
-    } else {
-      document.getElementById('weekday'+i).style.display = 'block';
-      document.getElementById('time_slot'+i).style.display = 'block';
-    }
-  }
-  if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
-  showplusminus(n);
-}
-
 document.addEventListener("DOMContentLoaded", function() {
   /* prevent accidental closing of browser window */
   {{ prevent_unsaved() }}
@@ -378,14 +330,60 @@ document.addEventListener("DOMContentLoaded", function() {
         {className: "info", position: "right"})
       }
     });
+
+  function showplusminus(n) {
+    document.getElementById('slotminus').style.visibility = ( n > 1 ? 'visible' : 'hidden' );
+    document.getElementById('slotplus').style.visibility = ( n < {{ maxlength["time_slots"] }} ? 'visible' : 'hidden' );
+  }
+  $("a.slotplus").click(function(e){
+    e.preventDefault();
+    var n = parseInt(document.getElementById('slots').value)+1;
+    document.getElementById('slots').value = '' + n;
+    if ( n <= 3 ) {
+      document.getElementById('weekday'+(n-1)).style.visibility = 'visible';
+      document.getElementById('time_slot'+(n-1)).style.visibility = 'visible';
+    } else {
+      document.getElementById('weekday'+(n-1)).style.display = 'block';
+      document.getElementById('time_slot'+(n-1)).style.display = 'block';
+    }
+    showplusminus(n);
+  });
+  $("a.slotminus").click(function(e){
+    e.preventDefault();
+    var n = parseInt(document.getElementById('slots').value)-1;
+    document.getElementById('slots').value = '' + n;
+    document.getElementById('weekday'+n).value = '';
+    document.getElementById('time_slot'+n).value ='';
+    if ( n < 3 ) {
+      document.getElementById('weekday'+n).style.visibility = 'hidden';
+      document.getElementById('time_slot'+n).style.visibility = 'hidden';
+    } else {
+      document.getElementById('weekday'+n).style.display = 'none';
+      document.getElementById('time_slot'+n).style.display = 'none';
+    }
+    showplusminus(n);
+  });
+  function showslots() {
+    var n = parseInt(document.getElementById('slots').value);
+    if ( n <= 0 ) document.getElementById('slots').value = '' + (n=1);
+    for ( var i = 0 ; i < n ; i++ ) {
+      if ( i < 3 ) {
+        document.getElementById('weekday'+i).style.visibility = 'visible';
+        document.getElementById('time_slot'+i).style.visibility = 'visible';
+      } else {
+        document.getElementById('weekday'+i).style.display = 'block';
+        document.getElementById('time_slot'+i).style.display = 'block';
+      }
+    }
+    if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
+    showplusminus(n);
+  }
   showslots();
+  window.onpageshow = function(e) {
+    console.log('onpageshow')
+    showslots()
+  };
 });
-
-window.onpageshow = function(e) {
-  console.log('onpageshow')
-  showslots()
-};
-
 
 
 </script>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -276,6 +276,54 @@ const subjOptions = [
   {% endfor %}
 ];
 
+function showplusminus(n) {
+  document.getElementById('slotminus').style.visibility = ( n > 1 ? 'visible' : 'hidden' );
+  document.getElementById('slotplus').style.visibility = ( n < {{ maxlength["time_slots"] }} ? 'visible' : 'hidden' );
+}
+$("a.slotplus").click(function(e){
+  e.preventDefault();
+  var n = parseInt(document.getElementById('slots').value)+1;
+  document.getElementById('slots').value = '' + n;
+  if ( n <= 3 ) {
+    document.getElementById('weekday'+(n-1)).style.visibility = 'visible';
+    document.getElementById('time_slot'+(n-1)).style.visibility = 'visible';
+  } else {
+    document.getElementById('weekday'+(n-1)).style.display = 'block';
+    document.getElementById('time_slot'+(n-1)).style.display = 'block';
+  }
+  showplusminus(n);
+});
+$("a.slotminus").click(function(e){
+  e.preventDefault();
+  var n = parseInt(document.getElementById('slots').value)-1;
+  document.getElementById('slots').value = '' + n;
+  document.getElementById('weekday'+n).value = '';
+  document.getElementById('time_slot'+n).value ='';
+  if ( n < 3 ) {
+    document.getElementById('weekday'+n).style.visibility = 'hidden';
+    document.getElementById('time_slot'+n).style.visibility = 'hidden';
+  } else {
+    document.getElementById('weekday'+n).style.display = 'none';
+    document.getElementById('time_slot'+n).style.display = 'none';
+  }
+  showplusminus(n);
+});
+function showslots() {
+  var n = parseInt(document.getElementById('slots').value);
+  if ( n <= 0 ) document.getElementById('slots').value = '' + (n=1);
+  for ( var i = 0 ; i < n ; i++ ) {
+    if ( i < 3 ) {
+      document.getElementById('weekday'+i).style.visibility = 'visible';
+      document.getElementById('time_slot'+i).style.visibility = 'visible';
+    } else {
+      document.getElementById('weekday'+i).style.display = 'block';
+      document.getElementById('time_slot'+i).style.display = 'block';
+    }
+  }
+  if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
+  showplusminus(n);
+}
+
 document.addEventListener("DOMContentLoaded", function() {
   /* prevent accidental closing of browser window */
   {{ prevent_unsaved() }}
@@ -302,38 +350,6 @@ document.addEventListener("DOMContentLoaded", function() {
       swapc("org_display{{i-1}}","org_display{{i}}");
     });
   {% endfor %}
-  function showplusminus(n) {
-    document.getElementById('slotminus').style.visibility = ( n > 1 ? 'visible' : 'hidden' );
-    document.getElementById('slotplus').style.visibility = ( n < {{ maxlength["time_slots"] }} ? 'visible' : 'hidden' );
-  }
-  $("a.slotplus").click(function(e){
-    e.preventDefault();
-    var n = parseInt(document.getElementById('slots').value)+1;
-    document.getElementById('slots').value = '' + n;
-    if ( n <= 3 ) {
-      document.getElementById('weekday'+(n-1)).style.visibility = 'visible';
-      document.getElementById('time_slot'+(n-1)).style.visibility = 'visible';
-    } else {
-      document.getElementById('weekday'+(n-1)).style.display = 'block';
-      document.getElementById('time_slot'+(n-1)).style.display = 'block';
-    }
-    showplusminus(n);
-  });
-  $("a.slotminus").click(function(e){
-    e.preventDefault();
-    var n = parseInt(document.getElementById('slots').value)-1;
-    document.getElementById('slots').value = '' + n;
-    document.getElementById('weekday'+n).value = '';
-    document.getElementById('time_slot'+n).value ='';
-    if ( n < 3 ) {
-      document.getElementById('weekday'+n).style.visibility = 'hidden';
-      document.getElementById('time_slot'+n).style.visibility = 'hidden';
-    } else {
-      document.getElementById('weekday'+n).style.display = 'none';
-      document.getElementById('time_slot'+n).style.display = 'none';
-    }
-    showplusminus(n);
-  });
   makeTopicSelector(
     topicOptions,
     {% if seminar.new or not seminar.topics %}[]{% else %}{{ seminar.topics | safe }}{% endif %},
@@ -362,24 +378,13 @@ document.addEventListener("DOMContentLoaded", function() {
         {className: "info", position: "right"})
       }
     });
-  function showslots() {
-    var n = parseInt(document.getElementById('slots').value);
-    if ( n <= 0 ) document.getElementById('slots').value = '' + (n=1);
-    for ( var i = 0 ; i < n ; i++ ) {
-      if ( i < 3 ) {
-        document.getElementById('weekday'+i).style.visibility = 'visible';
-        document.getElementById('time_slot'+i).style.visibility = 'visible';
-      } else {
-        document.getElementById('weekday'+i).style.display = 'block';
-        document.getElementById('time_slot'+i).style.display = 'block';
-      }
-    }
-    if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
-    showplusminus(n);
-    console.log('showed ' + n + ' slots')
-  }
   showslots();
 });
+
+window.onpageshow = function(e) {
+  console.log('onpageshow')
+  showslots()
+};
 
 
 

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -362,20 +362,26 @@ document.addEventListener("DOMContentLoaded", function() {
         {className: "info", position: "right"})
       }
     });
-  var n = parseInt(document.getElementById('slots').value);
-  if ( n <= 0 ) document.getElementById('slots').value = '' + (n=1);
-  for ( var i = 0 ; i < n ; i++ ) {
-    if ( i < 3 ) {
-      document.getElementById('weekday'+i).style.visibility = 'visible';
-      document.getElementById('time_slot'+i).style.visibility = 'visible';
-    } else {
-      document.getElementById('weekday'+i).style.display = 'block';
-      document.getElementById('time_slot'+i).style.display = 'block';
+  function showslots() {
+    var n = parseInt(document.getElementById('slots').value);
+    if ( n <= 0 ) document.getElementById('slots').value = '' + (n=1);
+    for ( var i = 0 ; i < n ; i++ ) {
+      if ( i < 3 ) {
+        document.getElementById('weekday'+i).style.visibility = 'visible';
+        document.getElementById('time_slot'+i).style.visibility = 'visible';
+      } else {
+        document.getElementById('weekday'+i).style.display = 'block';
+        document.getElementById('time_slot'+i).style.display = 'block';
+      }
     }
+    if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
+    showplusminus(n);
+    console.log('showed slots')
   }
-  if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
-  showplusminus(n);
+  showslots();
 });
+
+
 
 </script>
 

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -376,7 +376,7 @@ document.addEventListener("DOMContentLoaded", function() {
     }
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
-    console.log('showed slots')
+    console.log('showed ' + str(n) + ' slots')
   }
   showslots();
 });

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -378,9 +378,8 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  showslots();
+  // Make sure showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
-    console.log('onpageshow')
     showslots()
   };
 });

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -376,7 +376,7 @@ document.addEventListener("DOMContentLoaded", function() {
     }
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
-    console.log('showed ' + str(n) + ' slots')
+    console.log('showed ' + n + ' slots')
   }
   showslots();
 });


### PR DESCRIPTION
This PR addresses an issue we believe was caused by a user cutting and pasting times from an html page where an emdash was used for a time interval rather than an ascii hyphen.

Also fixes a bug that was causing time slots not to always be properly displayed when edit schedule page is reached via the back button (e.g. after a user input error).