### PR TITLE
Search improvements

### DIFF
--- a/seminars/app.py
+++ b/seminars/app.py
@@ -25,6 +25,7 @@ from seminars.utils import (
     topdomain,
     topics,
     toggle,
+    url_for_with_args,
 )
 from seminars.knowls import static_knowl
 from .seminar import series_header
@@ -146,6 +147,7 @@ def ctx_proc_userdata():
     data["static_knowl"] = static_knowl
     data["topdomain"] = topdomain()
     data["toggle"] = toggle
+    data["url_for_with_args"] = url_for_with_args
 
     return data
 

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -172,7 +172,7 @@ def talks_parser(info, query):
     if topdomain() == "mathseminars.org":
         query["subjects"] = ["math"]
 
-def seminars_parser(info, query):
+def seminars_parser(info, query, conference=False):
     parse_subject(info, query, prefix="seminar")
     parse_topic(info, query, prefix="seminar")
     parse_institution_sem(info, query)
@@ -185,7 +185,8 @@ def seminars_parser(info, query):
                      "comments"])
     parse_access(info, query, prefix="seminar")
     parse_language(info, query, prefix="seminar")
-    parse_daterange(info, query, time=False)
+    if conference:
+        parse_daterange(info, query, time=False)
 
     parse_substring(info, query, "name", ["name"])
     query["display"] = True
@@ -620,7 +621,8 @@ def _search_series(conference=False):
     info = to_dict(request.args, search_array=SemSearchArray(conference=conference))
     if "search_type" not in info:
         info["seminar_online"] = True
-        info["daterange"] = info.get("daterange", datetime.now(current_user.tz).strftime("%B %d, %Y -"))
+        if conference:
+            info["daterange"] = info.get("daterange", datetime.now(current_user.tz).strftime("%B %d, %Y -"))
     try:
         seminar_count = int(info["seminar_count"])
         seminar_start = int(info["seminar_start"])
@@ -631,7 +633,7 @@ def _search_series(conference=False):
         seminar_start = info["seminar_start"] = 0
     seminar_query = {"is_conference": conference}
     organizer = info.get("organizer","")
-    seminars_parser(info, seminar_query)
+    seminars_parser(info, seminar_query, conference=conference)
     # Ideally we would do the following with a single join query, but the backend doesn't support joins yet.
     # Instead, we use a function that returns a dictionary of all next talks as a function of seminar id.
     # One downside of this approach is that we have to retrieve ALL seminars, which we're currently doing anyway.

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -313,6 +313,7 @@ class TalkSearchArray(SearchArray):
         return [
             ("talks", "Search talks"),
             BasicSpacer("Times in %s" % (current_user.show_timezone("browse"))),
+            BasicSpacer("Showing %d results" % (len(info.results))),
         ]
 
     def hidden(self, info):

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -414,7 +414,6 @@ class SemSearchArray(SearchArray):
     def hidden(self, info):
         return []
 
-
 @app.route("/")
 def index():
     return _talks_index(subsection="talks")

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -639,7 +639,7 @@ def _search_series(conference=False):
     # The second downside is that we need to do two queries.
     if conference:
         sort = ["start_date", "end_date", "name"]
-        info["results"] = seminars_search(seminar_query, organizer=organizer, organizer_dict=all_organizers(),so rt=["start_date"])
+        info["results"] = seminars_search(seminar_query, organizer=organizer, organizer_dict=all_organizers(),sort=sort)
     else:
         info["results"] = next_talk_sorted(seminars_search(seminar_query, organizer=organizer, organizer_dict=all_organizers()))
     subsection = "conferences" if conference else "seminars"

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -19,7 +19,7 @@ from seminars.seminar import seminars_search, all_seminars, all_organizers, semi
 from flask_login import current_user
 import json
 from datetime import datetime, timedelta
-import pytz, sys
+import pytz
 from collections import Counter
 from dateutil.parser import parse
 
@@ -116,15 +116,15 @@ def parse_daterange_time(info, query):
             try:
                 start = tz.localize(parse(start))
                 sub_query["$gte"] = start
-            except Exception:
-                flash_error("Could not parse start date %s.  Error: " + sys.exc_info()[0], start)
+            except Exception as e:
+                flash_error("Could not parse start date %s.  Error: " + str(e), start)
         if end.strip():
             try:
                 end = tz.localize(parse(end))
                 end = end + datetime.timedelta(hours=23, minutes=59, seconds=59)
                 sub_query["$lte"] = end
-            except Exception:
-                flash_error("Could not parse end date %s.  Error: " + sys.exc_info()[0], end)
+            except Exception as e:
+                flash_error("Could not parse end date %s.  Error: " + str(e), end)
         if sub_query:
             query["start_time"] = sub_query
 

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -310,10 +310,10 @@ class TalkSearchArray(SearchArray):
         return self._print_table(self.array, info, layout_type="horizontal")
 
     def search_types(self, info):
+        print(info)
         return [
             ("talks", "Search talks"),
             BasicSpacer("Times in %s" % (current_user.show_timezone("browse"))),
-            BasicSpacer("Showing %d results" % (len(info.results))),
         ]
 
     def hidden(self, info):

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -376,17 +376,10 @@ class SemSearchArray(SearchArray):
             name="name",
             label="Name",
             width=textwidth,
-            example="Thule topology colloquium series",
         )
         organizer = TextBox(
             name="organizer",
             label="Organizer",
-            colspan=(1, 2, 1),
-            width=textwidth,
-        )
-        affiliation = TextBox(
-            name="affiliation",
-            label="Affiliation",
             colspan=(1, 2, 1),
             width=textwidth,
         )
@@ -403,8 +396,8 @@ class SemSearchArray(SearchArray):
             [subject, keywords],
             [topic, name],
             [institution, organizer],
-            [language, affiliation],
-            [access, date],
+            [language, ],
+            [access, date] if conference else [access],
         ]
 
         assert conference in [True, False]

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -121,7 +121,7 @@ def parse_daterange_time(info, query):
         if end.strip():
             try:
                 end = tz.localize(parse(end))
-                end = end + datetime.timedelta(hours=23, minutes=59, seconds=59)
+                end = end + timedelta(hours=23, minutes=59, seconds=59)
                 sub_query["$lte"] = end
             except Exception as e:
                 flash_error("Could not parse end date %s.  Error: " + str(e), end)

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -380,7 +380,6 @@ class SemSearchArray(SearchArray):
         organizer = TextBox(
             name="organizer",
             label="Organizer",
-            colspan=(1, 2, 1),
             width=textwidth,
         )
         date = TextBox(
@@ -413,7 +412,7 @@ class SemSearchArray(SearchArray):
         ]
 
     def hidden(self, info):
-        return []  # [("seminar_start", "seminar_start")]
+        return []
 
 
 @app.route("/")

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -380,7 +380,7 @@ class SemSearchArray(SearchArray):
         )
         organizer = TextBox(
             name="organizer",
-            label="organizer",
+            label="Organizer",
             colspan=(1, 2, 1),
             width=textwidth,
         )
@@ -629,6 +629,8 @@ def _search_series(conference):
     info = to_dict(request.args, search_array=SemSearchArray(conference=conference))
     if "search_type" not in info:
         info["seminar_online"] = True
+        info["daterange"] = info.get("daterange", datetime.now(current_user.tz).strftime("%B %d, %Y -")
+        )
     try:
         seminar_count = int(info["seminar_count"])
         seminar_start = int(info["seminar_start"])
@@ -660,8 +662,7 @@ def search_talks():
     )
     if "search_type" not in info:
         info["talk_online"] = True
-        info["daterange"] = info.get(
-            "daterange", datetime.now(current_user.tz).strftime("%B %d, %Y -")
+        info["daterange"] = info.get("daterange", datetime.now(current_user.tz).strftime("%B %d, %Y -")
         )
     try:
         talk_count = int(info["talk_count"])

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -265,7 +265,7 @@ class TalkSearchArray(SearchArray):
             name="affiliation",
             label="Affiliation",
             colspan=(1, 2, 1),
-            width=160 * 2 - 1 * 20,
+            width=textwidth,
         )
         title = TextBox(
             name="title",
@@ -280,7 +280,7 @@ class TalkSearchArray(SearchArray):
             example=datetime.now(current_user.tz).strftime("%B %d, %Y -"),
             example_value=True,
             colspan=(1, 2, 1),
-            width=160 * 2 - 1 * 20,
+            width=textwidth,
         )
         lang_dict = languages_dict()
         language = SelectBox(
@@ -378,14 +378,33 @@ class SemSearchArray(SearchArray):
             width=textwidth,
             example="Thule topology colloquium series",
         )
-
+        organizer = TextBox(
+            name="organizer",
+            label="organizer",
+            colspan=(1, 2, 1),
+            width=textwidth,
+        )
+        affiliation = TextBox(
+            name="affiliation",
+            label="Affiliation",
+            colspan=(1, 2, 1),
+            width=textwidth,
+        )
+        date = TextBox(
+            name="daterange",
+            id="daterange",
+            label="Date",
+            example=datetime.now(current_user.tz).strftime("%B %d, %Y -"),
+            example_value=True,
+            colspan=(1, 2, 1),
+            width=textwidth,
+        )
         self.array = [
             [subject, keywords],
             [topic, name],
-            [institution, access],
-            [language],
-            # [venue],
-            # [count],
+            [institution, organizer],
+            [language, affiliation],
+            [access, date],
         ]
 
         assert conference in [True, False]

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -115,14 +115,14 @@ def parse_daterange(info, query, time=True):
         if start.strip():
             try:
                 start = tz.localize(parse(start))
-                sub_query["$gte"] = start if time else start.date
+                sub_query["$gte"] = start if time else start.date()
             except Exception as e:
                 flash_error("Could not parse start date %s.  Error: " + str(e), start)
         if end.strip():
             try:
                 end = tz.localize(parse(end))
                 end = end + timedelta(hours=23, minutes=59, seconds=59)
-                sub_query["$lte"] = end if time else end.date
+                sub_query["$lte"] = end if time else end.date()
             except Exception as e:
                 flash_error("Could not parse end date %s.  Error: " + str(e), end)
         if sub_query:

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -624,7 +624,10 @@ def _search_series(conference):
     # Instead, we use a function that returns a dictionary of all next talks as a function of seminar id.
     # One downside of this approach is that we have to retrieve ALL seminars, which we're currently doing anyway.
     # The second downside is that we need to do two queries.
-    info["results"] = next_talk_sorted(seminars_search(seminar_query, organizer_dict=all_organizers()))
+    if conference:
+        info["results"] = seminars_search(seminar_query, organizer_dict=all_organizers(),sort=["start_date"])
+    else:
+        info["results"] = next_talk_sorted(seminars_search(seminar_query, organizer_dict=all_organizers()))
     subsection = "conferences" if conference else "seminars"
     title = "Search " + ("conferences" if conference else "seminar series")
     return render_template(

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -220,14 +220,14 @@ class TalkSearchArray(SearchArray):
 
         ## pick institution where it is held
         institution = SelectBox(
-            name="talk_institution",
+            name="institution",
             label="Institution",
             options=[("", ""), ("None", "No institution",),]
             + [(elt["shortname"], elt["name"]) for elt in institutions_shortnames()],
         )
 
         venue = SelectBox(
-            name="talk_venue",
+            name="venue",
             label=static_knowl("venue"),
             options=[("", ""),
                      ("online", "online"),
@@ -245,7 +245,7 @@ class TalkSearchArray(SearchArray):
         )
         ## type of access
         access = SelectBox(
-            name="talk_access",
+            name="access",
             label="Access",
             options=[
                 ("", ""),

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -310,7 +310,6 @@ class TalkSearchArray(SearchArray):
         return self._print_table(self.array, info, layout_type="horizontal")
 
     def search_types(self, info):
-        print(info)
         return [
             ("talks", "Search talks"),
             BasicSpacer("Times in %s" % (current_user.show_timezone("browse"))),

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -631,7 +631,7 @@ def _search_series(conference=False):
         seminar_count = info["seminar_count"] = 50
         seminar_start = info["seminar_start"] = 0
     seminar_query = {"is_conference": conference}
-    organizer = info.pop("organizer","")
+    organizer = info.get("organizer","")
     seminars_parser(info, seminar_query)
     # Ideally we would do the following with a single join query, but the backend doesn't support joins yet.
     # Instead, we use a function that returns a dictionary of all next talks as a function of seminar id.

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -600,7 +600,7 @@ def _iterator(organizer_dict, objects=True, organizer=""):
             # if organizer is specified do a keyword search on each text column other than seminar_id
             if organizer:
                 orgs = [org for org in organizer_dict.get(rec["shortname"]) if org["display"]]
-                if not [org for org in orgs if any([organizer in org[k].lower() for k in org.keys if k != "seminar_id" and isinstance(org[k],str)])]:
+                if not [org for org in orgs if any([organizer in org[k].lower() for k in org.keys() if k != "seminar_id" and isinstance(org[k],str)])]:
                     continue
             yield _construct(organizer_dict)(rec)
 

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -595,11 +595,13 @@ def _construct(organizer_dict, objects=True):
 
 def _iterator(organizer_dict, objects=True, organizer=""):
     organizer = organizer.strip().lower()
+    print("organizer: "+organizer)
     def object_iterator(cur, search_cols, extra_cols, projection):
         for rec in db.seminars._search_iterator(cur, search_cols, extra_cols, projection):
             # if organizer is specified do a keyword search on each text column other than seminar_id
             if organizer:
                 orgs = [org for org in organizer_dict.get(rec["shortname"]) if org.display]
+                print(orgs)
                 if not [org for org in orgs if any([organizer in org[k].lower() for k in org.keys if k != "seminar_id" and isinstance(org[k],str)])]:
                     continue
             yield _construct(organizer_dict)(rec)

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -595,13 +595,11 @@ def _construct(organizer_dict, objects=True):
 
 def _iterator(organizer_dict, objects=True, organizer=""):
     organizer = organizer.strip().lower()
-    print("organizer: "+organizer)
     def object_iterator(cur, search_cols, extra_cols, projection):
         for rec in db.seminars._search_iterator(cur, search_cols, extra_cols, projection):
             # if organizer is specified do a keyword search on each text column other than seminar_id
             if organizer:
-                orgs = [org for org in organizer_dict.get(rec["shortname"]) if org.display]
-                print(orgs)
+                orgs = [org for org in organizer_dict.get(rec["shortname"]) if org["display"]]
                 if not [org for org in orgs if any([organizer in org[k].lower() for k in org.keys if k != "seminar_id" and isinstance(org[k],str)])]:
                     continue
             yield _construct(organizer_dict)(rec)

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -601,7 +601,6 @@ def _iterator(organizer_dict, objects=True, organizer=""):
             if organizer:
                 orgs = [org for org in organizer_dict.get(rec["shortname"]) if org["display"]]
                 if not [org for org in orgs if any([organizer in org[k].lower() for k in org.keys() if k != "seminar_id" and isinstance(org[k],str)])]:
-                    continue
             yield _construct(organizer_dict)(rec)
 
     return object_iterator if objects else db.seminars._search_iterator

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -601,6 +601,7 @@ def _iterator(organizer_dict, objects=True, organizer=""):
             if organizer:
                 orgs = [org for org in organizer_dict.get(rec["shortname"]) if org["display"]]
                 if not [org for org in orgs if any([organizer in org[k].lower() for k in org.keys() if k != "seminar_id" and isinstance(org[k],str)])]:
+                    continue
             yield _construct(organizer_dict)(rec)
 
     return object_iterator if objects else db.seminars._search_iterator

--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -127,7 +127,7 @@
           <a href="{{ url_for('search_seminars') }}">Seminar series</a>
         </div>
         <div class="submenu-nav{% if subsection == 'conferences' %} submenu-active{% endif %}">
-          <a href="{{ url_for('search_conferences') }}">Conferences</a>
+          <a href="{{ url_for('search_conferences')+"?name="+request.args.get('name') }}">Conferences</a>
         </div>
         <div class="submenu-nav{% if subsection == 'talks' %} submenu-active{% endif %}">
           <a href="{{ url_for('search_talks') }}">Talks</a>

--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -124,13 +124,13 @@
     <header class="inner">
       <div class="submenu-inner">
         <div class="submenu-nav{% if subsection == 'seminars' %} submenu-active{% endif %}">
-          <a href="{{ url_for('search_seminars') }}">Seminar series</a>
+          <a href="{{ url_for_with_args('search_seminars', request.args) }}">Seminar series</a>
         </div>
         <div class="submenu-nav{% if subsection == 'conferences' %} submenu-active{% endif %}">
-          <a href="{{ url_for('search_conferences')+'/' }}">Conferences</a>
+          <a href="{{ url_for_with_args('search_conferences', request.args) }}">Conferences</a>
         </div>
         <div class="submenu-nav{% if subsection == 'talks' %} submenu-active{% endif %}">
-          <a href="{{ url_for('search_talks') }}">Talks</a>
+          <a href="{{ url_for_with_args('search_seminars', request.args) }}">Talks</a>
         </div>
       </div>
     </header>

--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -127,7 +127,7 @@
           <a href="{{ url_for('search_seminars') }}">Seminar series</a>
         </div>
         <div class="submenu-nav{% if subsection == 'conferences' %} submenu-active{% endif %}">
-          <a href="{{ url_for('search_conferences')+"?name="+request.args.get('name') }}">Conferences</a>
+          <a href="{{ url_for('search_conferences')+'/' }}">Conferences</a>
         </div>
         <div class="submenu-nav{% if subsection == 'talks' %} submenu-active{% endif %}">
           <a href="{{ url_for('search_talks') }}">Talks</a>

--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -130,7 +130,7 @@
           <a href="{{ url_for_with_args('search_conferences', request.args) }}">Conferences</a>
         </div>
         <div class="submenu-nav{% if subsection == 'talks' %} submenu-active{% endif %}">
-          <a href="{{ url_for_with_args('search_seminars', request.args) }}">Talks</a>
+          <a href="{{ url_for_with_args('search_talks', request.args) }}">Talks</a>
         </div>
       </div>
     </header>

--- a/seminars/templates/search_seminars.html
+++ b/seminars/templates/search_seminars.html
@@ -4,7 +4,7 @@
 <div class="search-container">
   <div id='searchseminars'>
     <form class='searchform' id='seminarsform' onsubmit="cleanSubmit(this.id)">
-      {{ info.search_array.html(info) | safe }}&nbsp;&nbsp;showing{{ info.results | length }} results
+      {{ info.search_array.html(info) | safe }}
     </form>
     <div class='searchresults'>
       <table class='ntdata'>

--- a/seminars/templates/search_seminars.html
+++ b/seminars/templates/search_seminars.html
@@ -4,7 +4,7 @@
 <div class="search-container">
   <div id='searchseminars'>
     <form class='searchform' id='seminarsform' onsubmit="cleanSubmit(this.id)">
-      {{ info.search_array.html(info) | safe }}
+      {{ info.search_array.html(info) | safe }}&nbsp;&nbsp;showing{{ info.results | length }} results
     </form>
     <div class='searchresults'>
       <table class='ntdata'>

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -14,7 +14,7 @@ from markupsafe import Markup, escape
 from psycopg2.sql import SQL
 from seminars import db
 from six import string_types
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode
 import iso639
 import pytz
 import re
@@ -649,5 +649,4 @@ def ics_file(talks, filename, user=current_user):
 
 def url_for_with_args(name, args, **kwargs):
     query = ('?' + urlencode(args)) if args else ''
-    print(query)
     return url_for(name, **kwargs) + query

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -649,4 +649,4 @@ def ics_file(talks, filename, user=current_user):
 
 def url_for_with_args(name, args, **kwargs):
     query = '?' + urlencode(args) if args else ''
-    return url_for(name, kwargs) + query
+    return url_for(name, **kwargs) + query

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -649,4 +649,5 @@ def ics_file(talks, filename, user=current_user):
 
 def url_for_with_args(name, args, **kwargs):
     query = ('?' + urlencode(args)) if args else ''
+    print(query)
     return url_for(name, **kwargs) + query

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -648,5 +648,5 @@ def ics_file(talks, filename, user=current_user):
     return send_file(bIO, attachment_filename=filename, as_attachment=True, add_etags=False)
 
 def url_for_with_args(name, args, **kwargs):
-    query = '?' + urlencode(args) if args else ''
+    query = ('?' + urlencode(args)) if args else ''
     return url_for(name, **kwargs) + query

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -647,3 +647,6 @@ def ics_file(talks, filename, user=current_user):
     bIO.seek(0)
     return send_file(bIO, attachment_filename=filename, as_attachment=True, add_etags=False)
 
+def url_for_with_args(name, args, **kwargs):
+    query = '?' + urlencode(args) if args else ''
+    return url_for(name, kwargs) + query


### PR DESCRIPTION
Includes the following:
-  fixes #474 (already fixed on live)
-  addresses #465 (conferences are now sorted by start date, you can pick your date range)
-  addresses #421 (layout of search options is the same across all searches, this leaves a "hole" on the conference search, but I'm sure we can think of something useful to fill the hole with)
- addresses #419 (search criteria are remembered when you switch between seminars/conferences/talks -- but only if you actually performed the search)
- adds search by organizer option for searching seminars and conferences

This needs more testing and feedback, but I think the easiest way to do that is to push to master and let people play with it.