### PR TITLE
full_name -> name plus updates to schema.md

### DIFF
--- a/Schema.md
+++ b/Schema.md
@@ -31,75 +31,101 @@ talks_subscriptions   | json        | dict as {shorname : list of counters}
 
 `institutions`: mainly universities, but some may be in other categories (e.g. MSRI/Banff)
 
-Column    | Type   | Notes
-----------|--------|------
-id        | bigint | auto
-shortname | text   | Assigned by admin on creation, used in urls, globally unique, cannot be changed (would break links)
-name      | text   |
-aliases   | text   | comma separated string of aliases
-location  | earth  |
-homepage  | text   |
-timezone  | text   | time zone code, e.g. "US/Eastern"
-city      | text   |
-type      | text   | university, institute, other
-admin     | text   | username responsible for updating, starts as creator
+Column    | Type        | Notes
+----------|-------------|------
+id        | bigint      | auto
+admin     | text        | users.email of user responsible for maintaining institution listing
+aliases   | text        | comma-delimited list of aliases, used when checking if an institution is known (and nowhere else)
+city      | text        | name of the city where the institution is located
+deleted   | text        | set if institution has been deleted (may still be revived)
+edited_at | timestamptz | timestamp of this version
+edited_by | bigint      | users.id of user who created this version
+homepage  | text        | URL of homepage for the institution
+location  | earth       | geolocation, not yet used
+name      | text        | name displayed for the institution (anchor for homepage link)
+shortname | text        | Assigned by admin on creation, used in urls, globally unique, cannot be changed (would break links)
+timezone  | text        | time zone code, e.g. "US/Eastern"
+type      | text        | university, institute, other, taken from selector
 
-`seminars`: seminars and conferences.  A coherent sequence of talks.
+`seminars`: seminars and conferences.  A coherent sequence of talks.  Columns makes [inherited] are copied into each talk that is part of the seminar and can then be customized for individual talks.
 
-Column       | Type        | Notes
--------------|-------------|------
-id           | bigint      | auto
-shortname    | text        | Assigned by owner, used in urls, globally unique, cannot be changed (would break links)
-name         | text        |
-topics       | text[]      |
-keywords     | text        |
-description  | text        | shown in search results and on seminar homepage, e.g. research seminar, conference, learning seminar
-comments     | text        |
-institutions | text[]      |
-timezone     | text        | time zone code, e.g. "America/New York"
-weekday      | smallint    | 0=Monday, 6=Sunday for consistency with Python
-start_time   | timestamptz | Start time, on Jan 1 2020.  Pick a fixed date to fix the conversion with utcoffset which postgres uses
-end_time     | timestamptz | End time, on Jan 1 2020.  Pick a fixed date to fix the conversion with utcoffset which postgres uses
-frequency    | int         | meeting frequency in days (often 7)
-room         | text        |
-is_conference| boolean     |
-homepage     | text        | link to external homepage
-display      | boolean     | allowed to show; will be true if and only if all organizers have creator privileges
-owner        | text        | email of owner of seminar, who controls the list of organizers (and can transfer ownership)
-archived     | boolean     | seminar is no longer active (and won't show up in users' list of seminars)
-online       | boolean     |
-access       | text        | we need to make a list of predefined access types
-live_link    | text        | some seminars may have a consistent link for attending
+Column              | Type        | Notes
+--------------------|-------------|------
+id                  | bigint      | auto
+access              | text        | "endorsed", "open", "users" [to be replaced by access_control] [inherited]
+access_control      | smallint    | live_link access control: 0=open  1=time, 2=password, 3=users, 3=internal reg, 5=external reg., n/a if not online [inherited]
+access_time         | integer     | number of minutes before talks.start_time that talks.live_link is shown if access_control=1, n/a otherwise [inherited]
+accces_hint         | text        | hint for live_link password, required if access_control=2, n/a otherwise [inherited]
+access_registration | text        | URL (possibly a mailto) for external registration if access_control=5, n/a otherwise [inhertied]
+comments            | text        |
+deleted             | boolean     | True if seminar has been deleted (it can still be revived)
+description         | text        | shown in search results and on seminar homepage, e.g. research seminar, conference, learning seminar
+display             | boolean     | shown on browse/search pages; will be set once the owner has creator privileges
+edited_at           | timestamptz | timestamp of this version
+edited_by           | bigint      | users.id of user who created this version
+end_date            | date        | end date of the conference, n/a for semianr series
+frequency           | iinteger    | for seminar series, the periodicity of the meetings (0=no fixed schedule, 7=weekly, 14=biweekly, 21=triweekly), n/a for conferences
+homepage            | text        | link to external homepage (if any)
+institutions        | text[]      | list of institutions.shortname values for the institutions associated to this semianr
+is_conference       | boolean     | True for conferences, False for seminar_series; per_day, start_date, end_date are specific to conferences, frequency, weekdays, time_slots are specific to seminar_series
+language            | text        | language abbreviation taken from language selector, required [inherited]
+live_link           | text        | URL for online meeting link (e.g. Zoom) if fixed, may be set to "see comments" (once access_control is in place, this should no longer be necessary) [inherited]
+name                | text        |
+online              | boolean     | True if talks in the seminar can be viewed online [inherited]
+owner               | text        | users.email of owner of seminar, who controls the list of organizers (and can transfer ownership)
+per_day             | integer     | number of talks per day of a conference (only used to layout schedule), n/a for seminar_series
+room                | text        | physical location of the conference, if any [inherited]
+shortname           | text        | Unique identifier assigned by owner, used in urls, cannot be changed (would break links)
+start_date          | date        | start date of the conference, n/a for seminar_series
+stream_link         | text        | URL for non-interactive livestream (e.g. YouTube), not yet used [inherited]
+subjects            | text[]      | [to be removed once we switch to new topics design]
+timezone            | text        | time zone code, e.g. "America/New York"
+time_slots          | text[]      | list of time slots for seminar series with frequency != 0, n/a for conferences.  Each entry is a daytime interval of the form "HH:MM-HH:MM"; if end time is less than start time the interval extends to the next day.  All of relative to the timezone of the seminar.
+topics              | text[]      | list of topics.abbreviation for each topic associated ot the seminar [inherited]
+visibility          | smallint    | 0 = private, 1 = unlisted, 2 = public (only talks in public seminars are shown on the browse/search pages)
+weekdays            | smallint[]  | list of weekdays (0=Monday, 6=Sunday) one for each time slot for the seminar series, n/a/ for conferences
 
 `talks`: table for individual lectures
 
 Column              | Type        | Notes
 --------------------|-------------|------
 id                  | bigint      | auto
-title               | text        |
-abstract            | text        |
-token               | text        | give permission for speaker to edit
-topics              | text[]      |
-keywords            | text        |
-comments            | text        |
-seminar_id          | text        | shortname of seminar (every talk has to be part of a seminar)
-seminar_ctr         | int         | Counter of talks within a given seminar
-display             | boolean     | whether seminar creator has creator privileges
-start_time          | timestamptz |
+abstract            | text        | may contain latex
+access              | text        | "endorsed", "open", "users" [to be replaced by access_control] [inherited]
+access_control      | smallint    | live_link access control: 0=open  1=time, 2=password, 3=users, 3=internal reg, 5=external reg., n/a if not online [inherited]
+access_time         | integer     | number of minutes before talk start time live_link is shown if access_control=1, n/a otherwise [inherited]
+accces_hint         | text        | hint for live_link password, required if access_control=2, n/a otherwise [inherited]
+access_registration | text        | URL (possibly a mailto) for external registration if access_control=5, n/a otherwise [inhertied]
+comments            | text        | talk specific comments to be displayed in addition to seminar comments
+deleted             | boolean     | indicates talk has been deleted (but can still be revived)
+deleted_with_seminar| boolean     | indicates talk was deleted when seminar was deleted (will be automatically revived if/when seminar is revived)
+display             | boolean     | whether to display publicly (set if creator is True for the user who created the seminar)
+edited_at           | timestamptz | timestamp of this version
+edited_by           | bigint      | users.id of user who created this version
 end_time            | timestamptz |
-timezone            | text        | time zone code, e.g. "America/New York" (this isn't exactly the same as the tz info contained within the datetime, though it's related)
-speaker             | text        | full name, not username
-speaker_email       | text        | username, may be null
-speaker_affiliation | text        | name of university, may be null
-speaker_homepage    | text        |
-online              | boolean     |
-access              | text        | we need to make a list of predefined access types
-live_link           | text        |
-room                | text        |
-video_link          | text        | archive video link
-slides_link         | text        | link to slides
+hidden              | boolean     | if True, the talk will be visible only on the Edit schedule page for the seminar (independent of display)
+language            | text        | language abbreviation taken from language selector, required [inherited]
+live_link           | text        | URL for online meeting link (e.g. Zoom), may be set to "see comments" [inherited]
+online              | boolean     | True if talk can be viewed online (copied from seminar), note that both online and room may be set
+paper_link          | text        | URL providing link to a paper the talk is about
+room                | text        | physical location of the talk [inherited]
+seminar_ctr         | int         | unique identifier for this talk among the talks in this seminar
+seminar_id          | text        | seminars.shortname of seminar containing this talk (every talk belongs to some semianr)
+slides_link         | text        | URL providing link to slides for the talk
+speaker             | text        | full name of the speaker (required) [to be replaced by speakers]
+speaker_email       | text        | email address of the speaker, it need not match the email of any user [to be replaced by speaker_emails]
+speaker_affiliation | text        | free text, it need not be present in the insitutions table (optional) [to be replaced by speaker_affiliations]
+speaker_homepage    | text        | URL of the homepage for the speaker (speaker's name will be anchor for this link) [to be replaced by speaker_homepages]
+start_time          | timestamptz | 
+stream_link         | text        | URL for non-interactive livestream (e.g. YouTube), not yet used [inherited]
+title               | text        | may contain latex, will be shown as TBA if left blank
+token               | text        | used to give permission for speaker to edit
+subjects            | text[]      | [to be removed when we switsh to new topics]
+timezone            | text        | time zone, e.g. "America/New York" (not necessarily the same as the tz in start_time, but related) (copied from semianr)
+topics              | text[]      | list of topic identifiers for the talk
+video_link          | text        | archived video recording of the talk (should be set after the talk takes place)
 
-`topics`: table of topics for seminars and talks
+`topics`: table of topics for seminars and talks (to be changed soon)
 
 Column       | Type   |  Notes
 -------------|--------|-------
@@ -117,10 +143,10 @@ These tables record various multi-multi relations between entities in the databa
 Column     | Type    | Notes
 -----------|---------|------
 id         | bigint  | auto
-seminar_id | text    |
-email      | text    |
-full_name  | text    |
-order      | int     | Controls order organizers displayed
-curator    | boolean | whether to include in the curator (rather than the organizer field)
-display    | boolean | whether to display on the page
-contact    | boolean | whether to include the email
+seminar_id | text    | seminars.shortname of seminar this organizer record belongs to
+email      | text    | email of the organizer
+homepage   | text    | URL for the homepage of the organizer
+name       | text    | full name of the organizer
+curator    | boolean | True if curator, False if organizer
+display    | boolean | whether to display on the page for the series
+order      | integer | controls the order in which organizers are displayed

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -605,6 +605,8 @@ def save_seminar():
     elif seminar.organizers == new_version.organizers:
         flash("No changes made to series.")
     if seminar.new or seminar.organizers != new_version.organizers:
+        print(seminar.organizers)
+        print(new_version.organizers)
         new_version.save_organizers()
         if not seminar.new:
             flash("Series organizers updated!")

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -541,8 +541,8 @@ def save_seminar():
                 D[col] = process_user_input(val, col, typ, tz)
             except Exception as err:  # should only be ValueError's but let's be cautious
                 errmsgs.append(format_input_errmsg(err, val, col))
-        if D["homepage"] or D["email"] or D["full_name"]:
-            if not D["full_name"]:
+        if D["homepage"] or D["email"] or D["name"]:
+            if not D["name"]:
                 errmsgs.append(format_errmsg("Organizer name cannot be left blank."))
             D["order"] = len(organizer_data)
             # WARNING the header on the template says organizer
@@ -553,17 +553,17 @@ def save_seminar():
                 flash_warning(
                     "The email address %s of organizer %s will be publicly visible.<br>%s",
                     D["email"],
-                    D["full_name"],
+                    D["name"],
                     "Set homepage or disable display to prevent this.",
                 )
             if D["email"]:
                 r = db.users.lookup(D["email"])
                 if r and r["email_confirmed"]:
-                    if D["full_name"] != r["name"]:
+                    if D["name"] != r["name"]:
                         flash_warning(
                             format_warning(
                                 "Organizer name %s does not match the name %s of the account with email address %s.<br>Please verify that you have spelled the name correctly.",
-                                D["full_name"],
+                                D["name"],
                                 r["name"],
                                 D["email"],
                             )
@@ -842,6 +842,9 @@ def save_talk():
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:
         errmsgs.append("Talks must have both a start and end time.")
+    if data["title"].upper() == "TBA":
+        data["title"] = ""
+        flash_warning("TBA title left blank (it will appear as TBA)")
     data["topics"] = clean_topics(data.get("topics"))
     data["language"] = clean_language(data.get("language"))
     data["subjects"] = clean_subjects(data.get("subjects"))

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -526,7 +526,7 @@ def save_seminar():
     else:
         data["weekdays"] = []
         data["time_slots"] = []
-    organizer_data = []
+    organizers = []
     contact_count = 0
     for i in range(10):
         D = {"seminar_id": seminar.shortname}
@@ -544,7 +544,7 @@ def save_seminar():
         if D["homepage"] or D["email"] or D["name"]:
             if not D["name"]:
                 errmsgs.append(format_errmsg("Organizer name cannot be left blank."))
-            D["order"] = len(organizer_data)
+            D["order"] = len(organizers)
             # WARNING the header on the template says organizer
             # but it sets the database column curator, so the
             # boolean needs to be inverted
@@ -577,7 +577,7 @@ def save_seminar():
                         )
                     if D["display"]:
                         contact_count += 1
-            organizer_data.append(D)
+            organizers.append(D)
     if contact_count == 0:
         errmsgs.append(
             format_errmsg(
@@ -591,7 +591,7 @@ def save_seminar():
     if errmsgs:
         return show_input_errors(errmsgs)
     else:  # to make it obvious that these two statements should be together
-        new_version = WebSeminar(shortname, data=data, organizer_data=organizer_data)
+        new_version = WebSeminar(shortname, data=data, organizers=organizers)
 
     # Warnings
     if not data["topics"]:
@@ -602,9 +602,9 @@ def save_seminar():
         new_version.save()
         edittype = "created" if new else "edited"
         flash("Series %s successfully!" % edittype)
-    elif seminar.organizer_data == new_version.organizer_data:
+    elif seminar.organizers == new_version.organizers:
         flash("No changes made to series.")
-    if seminar.new or seminar.organizer_data != new_version.organizer_data:
+    if seminar.new or seminar.organizers != new_version.organizers:
         new_version.save_organizers()
         if not seminar.new:
             flash("Series organizers updated!")

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -605,8 +605,6 @@ def save_seminar():
     elif seminar.organizers == new_version.organizers:
         flash("No changes made to series.")
     if seminar.new or seminar.organizers != new_version.organizers:
-        print(seminar.organizers)
-        print(new_version.organizers)
         new_version.save_organizers()
         if not seminar.new:
             flash("Series organizers updated!")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -203,7 +203,7 @@
           {% endif %}
           {% if i < (seminar.organizer_data | length) %}
             <td>
-              <input name="org_full_name{{i}}" value="{{ seminar.organizer_data[i].get('full_name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['full_name'] }}" />
+              <input name="org_name{{i}}" value="{{ seminar.organizer_data[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
             </td>
             <td>
               <input name="org_homepage{{i}}" value="{{ seminar.organizer_data[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizer_data[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_full_name{{i}}" style="width:180px;" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
@@ -295,7 +295,7 @@ document.addEventListener("DOMContentLoaded", function() {
   {% for i in range(1,(seminar.organizer_data | length)) %}
     $("a.swap{{i}}").click(function(e){
       e.preventDefault();
-      swapv("org_full_name{{i-1}}","org_full_name{{i}}");
+      swapv("org_name{{i-1}}","org_name{{i}}");
       swapv("org_homepage{{i-1}}","org_homepage{{i}}");
       swapv("org_email{{i-1}}","org_email{{i}}");
       swapc("org_curator{{i-1}}","org_curator{{i}}");

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -196,28 +196,28 @@
         </thead>
         {% for i in range(maxlength["organizers"]) %}
         <tr>
-          {% if i > 0 and i < (seminar.organizer_data | length) %}
+          {% if i > 0 and i < (seminar.organizers | length) %}
             <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>
           {% else %}
             <td></td>
           {% endif %}
-          {% if i < (seminar.organizer_data | length) %}
+          {% if i < (seminar.organizers | length) %}
             <td>
-              <input name="org_name{{i}}" value="{{ seminar.organizer_data[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
+              <input name="org_name{{i}}" value="{{ seminar.organizers[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
             </td>
             <td>
-              <input name="org_homepage{{i}}" value="{{ seminar.organizer_data[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
+              <input name="org_homepage{{i}}" value="{{ seminar.organizers[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
             </td>
             <td>
-              <input name="org_email{{i}}" value="{{ seminar.organizer_data[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
+              <input name="org_email{{i}}" value="{{ seminar.organizers[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
             </td>
             <td align="center">
               {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}
               {# but it is displayed in a column labeleled "organizer" so it is checked when curator is false #}
-              <input type="checkbox" name="org_curator{{i}}" value="yes" {% if not seminar.organizer_data[i].get("curator") %}checked{% endif %} />
+              <input type="checkbox" name="org_curator{{i}}" value="yes" {% if not seminar.organizers[i].get("curator") %}checked{% endif %} />
             </td>
             <td align="center">
-              <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizer_data[i].get("display") %}checked{% endif %} />
+              <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
             <td><input name="org_name{{i}}" style="width:180px;" /></td>
@@ -292,7 +292,7 @@ document.addEventListener("DOMContentLoaded", function() {
     $('input[name="'+b+'"]')[0].checked = x;
     x = $('input[name="'+a+'"]')[0].checked;
   }
-  {% for i in range(1,(seminar.organizer_data | length)) %}
+  {% for i in range(1,(seminar.organizers | length)) %}
     $("a.swap{{i}}").click(function(e){
       e.preventDefault();
       swapv("org_name{{i-1}}","org_name{{i}}");

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -41,7 +41,7 @@
     <tr>
       <td>{{ KNOWL("title") }}</td>
       <td><input name="title" id="inp_title" value="{{ talk.title | blanknone }}" style="width:600px;" maxlength="{{ maxlength['title'] }}" placeholder="Leave blank if TBA.  $\TeX$ symbols are OK here." /></td>
-      <td class="forminfo" />Capitalize first word and proper nouns only.</td>
+      <td class="forminfo" />Capitalize first word and proper nouns only.  Leave blank if TBA.</td>
     </tr>
     {% if topdomain != "mathseminars.org" %} {# FIXME: temporary measure during addition of physics #}
     <tr>

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -184,7 +184,7 @@ def seminars_parser(info, query, org_query={}, conference=False):
                      "homepage",
                      "shortname",
                      "comments"])
-    org_cols = ["name", "full_name", "homepage"]
+    org_cols = ["name", "name", "full_name", "homepage"] #FIXME: remove full_name
     if current_user.is_subject_admin(None):
         org_cols.append("email")
     parse_substring(info, org_query, "organizer", org_cols)

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -314,7 +314,7 @@ title:
     this should be in <a href="https://en.wikipedia.org/wiki/Letter_case#Sentence_case">sentence case</a>,
     with only the first word and proper nouns capitalized.
     If you have co-authors, it is better to mention them not here, 
-    but in the abstract.
+    but in the abstract.  If the title is not yet known, leave it blank; it will then appear as "TBA".
 abstract:
   title: Abstract
   contents: |

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -88,7 +88,7 @@ class WebSeminar(object):
                         "seminar_id": self.shortname,
                         "email": current_user.email,
                         "homepage": current_user.homepage,
-                        "full_name": current_user.name,
+                        "name": current_user.name,
                         "order": 0,
                         "curator": False,
                         "display": True,
@@ -187,8 +187,13 @@ class WebSeminar(object):
         self.description = s[0].upper() + s[1:] if s else ""
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
-            if hasattr(self,"attr"):
+            if hasattr(self, "attr"):
                 delattr(self,"attr")
+        for i in range(len(self.organizers)):
+            if not self.organizers[i].get("name") and self.organizers[i].get("full_name"):
+                self.organizers[i]["name"] = self.organizers[i]["full_name"]
+            if hasattr(self, "full_name"):
+                delattr(self.organizers[i], "full_name")
 
     def visible(self):
         """
@@ -433,7 +438,7 @@ class WebSeminar(object):
             show = rec["curator"] if curators else not rec["curator"]
             if show and rec["display"]:
                 link = (rec["homepage"] if rec["homepage"] else ("mailto:%s" % (rec["email"]) if rec["email"] else ""))
-                name = rec["full_name"] if rec["full_name"] else link
+                name = rec["name"] if rec["name"] else link
                 if name:
                     namelink = '<a href="%s">%s</a>' % (link, name) if link else name
                     if link and db.users.count({"email":rec["email"], "email_confirmed":True}):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -222,8 +222,8 @@ class WebSeminar(object):
         # Need to allow for deleting organizers, so we delete them all then add them back
         with DelayCommit(db):
             db.seminar_organizers.delete({"seminar_id": self.shortname})
-            for i in range(len(self.organizers)):
-                self.
+            for i in range(len(self.organizers)): # FIXME: remove once this code is live
+                self.organizers[i]["full_name"] = self.organizers[i]["name"] # FIXME: remove once this code is live
             db.seminar_organizers.insert_many(self.organizers)
 
     # We use timestamps on January 1, 2020 to save start and end times

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -112,7 +112,6 @@ class WebSeminar(object):
                 db.seminar_organizers.search({"seminar_id": self.shortname}, sort=["order"])
             )
         self.organizers = organizers
-        print(self.organizers)
         self.cleanse()
 
     def __repr__(self):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -194,6 +194,7 @@ class WebSeminar(object):
             if not org.get("name") and org.get("full_name"):
                 org["name"] = org["full_name"]
             killattr(org, "full_name")
+            print(org)
             self.organizers[i] = org
 
     def visible(self):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -112,6 +112,7 @@ class WebSeminar(object):
                 db.seminar_organizers.search({"seminar_id": self.shortname}, sort=["order"])
             )
         self.organizers = organizers
+        print(self.organizers)
         self.cleanse()
 
     def __repr__(self):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -15,6 +15,7 @@ from seminars.utils import (
     toggle,
     topic_dict,
     weekdays,
+    killattr,
 )
 from lmfdb.utils import flash_error
 from lmfdb.backend.utils import DelayCommit, IdentifierWrapper
@@ -187,13 +188,11 @@ class WebSeminar(object):
         self.description = s[0].upper() + s[1:] if s else ""
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
-            if hasattr(self, "attr"):
-                delattr(self,"attr")
+            killatr(self, "attr")
         for i in range(len(self.organizers)):
             if not self.organizers[i].get("name") and self.organizers[i].get("full_name"):
                 self.organizers[i]["name"] = self.organizers[i]["full_name"]
-            if hasattr(self, "full_name"):
-                delattr(self.organizers[i], "full_name")
+            killattr(self.organizers[i], "full_name")
 
     def visible(self):
         """

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -188,7 +188,7 @@ class WebSeminar(object):
         self.description = s[0].upper() + s[1:] if s else ""
         # remove columns we plan to drop
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
-            killatr(self, "attr")
+            killattr(self, "attr")
         for i in range(len(self.organizers)):
             if not self.organizers[i].get("name") and self.organizers[i].get("full_name"):
                 self.organizers[i]["name"] = self.organizers[i]["full_name"]

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -190,9 +190,11 @@ class WebSeminar(object):
         for attr in ["start_time","end_time","start_times","end_times","weekday","archived"]:
             killattr(self, "attr")
         for i in range(len(self.organizers)):
-            if not self.organizers[i].get("name") and self.organizers[i].get("full_name"):
-                self.organizers[i]["name"] = self.organizers[i]["full_name"]
-            killattr(self.organizers[i], "full_name")
+            org = self.organizers[i]
+            if not org.get("name") and org.get("full_name"):
+                org["name"] = org["full_name"]
+            killattr(org, "full_name")
+            self.organizers[i] = org
 
     def visible(self):
         """

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -193,8 +193,7 @@ class WebSeminar(object):
             org = self.organizers[i]
             if not org.get("name") and org.get("full_name"):
                 org["name"] = org["full_name"]
-            killattr(org, "full_name")
-            print(org)
+            org.pop("full_name")
             self.organizers[i] = org
 
     def visible(self):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -65,6 +65,10 @@ maxlength = {
     'weekdays' : MAX_SLOTS,
 }
 
+def killattr(obj,attr)
+    if hasattr(obj,attr):
+        delattr(obj,attr)
+
 def topdomain():
     # return 'mathseminars.org'
     # return 'researchseminars.org'

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -44,7 +44,6 @@ maxlength = {
     'city' : MAX_NAME_LEN,
     'comments' : MAX_TEXT_LEN,
     'description' : MAX_DESCRIPTION_LEN,
-    'full_name' : MAX_NAME_LEN, # FIXME we should really rename this column to name
     'homepage' : MAX_URL_LEN,
     'institutions.name' : MAX_DESCRIPTION_LEN,
     'live_link' : MAX_URL_LEN,

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -65,7 +65,7 @@ maxlength = {
     'weekdays' : MAX_SLOTS,
 }
 
-def killattr(obj,attr)
+def killattr(obj,attr):
     if hasattr(obj,attr):
         delattr(obj,attr)
 


### PR DESCRIPTION
The WebSeminar object attribute organizer_data has been replaced with organizers, and the organizer dictionary now contains only "name" not "full_name".

When loading seminar_organizers, if name is null or empty and full_name is not, full_name will be copied to name (and removed from the organizer dictionary so the code cannot reference full_name).

When saving name is copied to full_name and both are written (this is to ensure backward compatibility while this PR is on master but not on live, once it is merged to live we should copy full_name to name for every record in seminar_organizers, remove the code that sets full_name when saving, and we will then be in a position to drop the full_name column).
