### PR TITLE
Addresses #486

### DIFF
--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -388,7 +388,7 @@ document.addEventListener("DOMContentLoaded", function() {
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }
-  $("input.org_name").change(function(showswaps));
+  $("input.org_name").change(showswaps);
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
     console.log("onpageshow")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -280,7 +280,16 @@ const subjOptions = [
 document.addEventListener("DOMContentLoaded", function() {
   /* prevent accidental closing of browser window */
   {{ prevent_unsaved() }}
-
+  function showswaps() {
+    var n = {{maxlength["organizers"]}};
+    var x = $('input[class="org_name"]');
+    var m = 0;
+    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
+    console.log("showswaps m = "+m)
+    for ( var i = 1 ; i < n ; i++ )
+      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
+  }
+  $("input.org_name").change(showswaps);
   function swapv(a,b) {
     var x = $('input[name="'+a+'"]')[0].value;
     $('input[name="'+a+'"]')[0].value = $('input[name="'+b+'"]')[0].value;
@@ -301,6 +310,7 @@ document.addEventListener("DOMContentLoaded", function() {
       swapv("org_email{{i-1}}","org_email{{i}}");
       swapc("org_curator{{i-1}}","org_curator{{i}}");
       swapc("org_display{{i-1}}","org_display{{i}}");
+      showswaps();
     });
   {% endfor %}
   makeTopicSelector(
@@ -379,16 +389,6 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  function showswaps() {
-    var n = {{maxlength["organizers"]}};
-    var x = $('input[class="org_name"]');
-    var m = 0;
-    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
-    console.log("showswaps m = "+m)
-    for ( var i = 1 ; i < n ; i++ )
-      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
-  }
-  $("input.org_name").change(showswaps);
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
     console.log("onpageshow")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -291,7 +291,9 @@ document.addEventListener("DOMContentLoaded", function() {
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }
-  $("input.org_name").input(showswaps); $("input.org_homepage").input(showswaps); $("input.org_email").input(showswaps);
+  $("input.org_name").change(showswaps); $("input.org_homepage").change(showswaps); $("input.org_email").change(showswaps);
+  $("input.org_name").paste(showswaps); $("input.org_homepage").paste(showswaps); $("input.org_email").paste(showswaps);
+  $("input.org_name").keyup(showswaps); $("input.org_homepage").keyup(showswaps); $("input.org_email").keyup(showswaps);
   function swapv(a,b) {
     var x = $('input[name="'+a+'"]')[0].value;
     $('input[name="'+a+'"]')[0].value = $('input[name="'+b+'"]')[0].value;

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -1,4 +1,16 @@
 {% extends "homepage.html" %}
+<script type="text/javascript">
+function showswaps() {
+  console.log("showswaps")
+  var n = {{maxlength["organizers"]}};
+  var x = $('input[class="org_name"]');
+  var m = 0;
+  for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
+  console.log("m ="+m)
+  for ( var i = 1 ; i < n ; i++ )
+    document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
+}
+</script>
 {% block content %}
 
   {% if lock %}
@@ -378,17 +390,10 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  function showswaps() {
-    var n = {{maxlength["organizers"]}};
-    var x = $('input[class="org_name"]');
-    var m = 0;
-    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
-    for ( var i = 1 ; i < n ; i++ )
-      document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
-  }
   $('input[class="org_name"]').change(showswaps);
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
+    console.log("onpageshow")
     showswaps()
     showslots()
   };

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -197,7 +197,7 @@
         {% for i in range(maxlength["organizers"]) %}
         <tr>
           {% if i > 0 %}
-            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a id="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
+            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" id="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
           {% else %}
             <td></td>
           {% endif %}
@@ -293,7 +293,7 @@ document.addEventListener("DOMContentLoaded", function() {
     x = $('input[name="'+a+'"]')[0].checked;
   }
   {% for i in range(1,maxlength["organizers"]) %}
-    document.getElementById('swap{{i}}').click(function(e){
+    $("a.swap{{i}}").click(function(e){
       e.preventDefault();
       swapv("org_name{{i-1}}","org_name{{i}}");
       swapv("org_homepage{{i-1}}","org_homepage{{i}}");

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -108,7 +108,7 @@
         <input id="slots" style="display:none;" value="{{ seminar.time_slots|length }}">
         <tr>
           <td>{{ KNOWL("periodicity") }}</td>
-          <td><select id="frequency" name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:610px;" onchange="showtimes(); return false;" />
+          <td><select id="frequency" name="frequency" value="{{ seminar.frequency | blanknone }}" style="width:610px;" onchange="showtimes();" />
               <option value="0" {% if not seminar.frequency %}selected{% endif %}>no fixed schedule</option>
               <option value="7" {% if seminar.frequency == 7 %}selected{% endif %}>weekly</option>
               <option value="14" {% if seminar.frequency == 14 %}selected{% endif %}>every other week</option>
@@ -196,8 +196,9 @@
         </thead>
         {% for i in range(maxlength["organizers"]) %}
         <tr>
-          {% if i > 0 and i < (seminar.organizers | length) %}
-            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>
+          {% if i > 0 %}
+            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px; {% if i >= (seminar.organizers | length) %}visibility:hidden;{% endif %}"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>
+            <script>function showswap{{i}}() { if ( $('.swap{{i}}').show(); }</script>
           {% else %}
             <td></td>
           {% endif %}
@@ -220,7 +221,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="showswap{{i}}();" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -398,7 +398,7 @@ document.addEventListener("DOMContentLoaded", function() {
     for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
     console.log("showswaps m = "+m)
     for ( var i = 1 ; i < n ; i++ )
-      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible;' : 'hidden' );
+      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -292,8 +292,6 @@ document.addEventListener("DOMContentLoaded", function() {
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }
   $("input.org_name").change(showswaps); $("input.org_homepage").change(showswaps); $("input.org_email").change(showswaps);
-  $("input.org_name").paste(showswaps); $("input.org_homepage").paste(showswaps); $("input.org_email").paste(showswaps);
-  $("input.org_name").keyup(showswaps); $("input.org_homepage").keyup(showswaps); $("input.org_email").keyup(showswaps);
   function swapv(a,b) {
     var x = $('input[name="'+a+'"]')[0].value;
     $('input[name="'+a+'"]')[0].value = $('input[name="'+b+'"]')[0].value;

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -197,7 +197,8 @@
         {% for i in range(maxlength["organizers"]) %}
         <tr>
           {% if i > 0 %}
-            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px; {% if i >= (seminar.organizers | length) %}visibility:hidden;{% endif %}"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>
+            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
+            <script>function showswap{{i}}() { $('.swap{{i}}').show(); }</script>
           {% else %}
             <td></td>
           {% endif %}
@@ -219,7 +220,8 @@
             <td align="center">
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){$('.swap{{i}}').show();})()" /></td>
+          {% else %}
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="showswap{{i}}();" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');document.getElementById('show{{i}}').style.visibility='visible';})()" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');document.getElementById('swap{{i}}').style.visibility='visible';})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input class="org_name" name="org_name{{i}}" style="width:180px;" /></td>
+            <td><input class="org_name" name="org_name{{i}}" style="width:180px;" onchange="showswaps();"/></td>
             <td><input class="org_homepage" name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input class="org_email" name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -221,20 +221,9 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-<script type="text/javascript">
-  function showswaps() {
-    var n = {{maxlength["organizers"]}};
-    var x = $('input[class="org_name"]');
-    var m = 0;
-    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
-    console.log("showswaps m = "+m)
-    for ( var i = 1 ; i < n ; i++ )
-      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
-  }
-</script>
-            <td><input class="org_name" name="org_name{{i}}" style="width:180px;" onchange="showswaps();"/></td>
-            <td><input class="org_homepage" name="org_homepage{{i}}" style="width:220px;" /></td>
-            <td><input class="org_email" name="org_email{{i}}" style="width:220px;" /></td>
+            <td><input class="org_name" name="org_name{{i}}" style="width:180px;" maxlength="{{ maxlength['name'] }}" /></td>
+            <td><input class="org_homepage" name="org_homepage{{i}}" style="width:220px;" maxlength="{{ maxlength['hoempage'] }}"/></td>
+            <td><input class="org_email" name="org_email{{i}}" style="width:220px;" maxlength="{{ maxlength['email'] }}" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
             <td align="center"><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
           {% endif %}
@@ -390,7 +379,7 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  /*function showswaps() {
+  function showswaps() {
     var n = {{maxlength["organizers"]}};
     var x = $('input[class="org_name"]');
     var m = 0;
@@ -398,7 +387,8 @@ document.addEventListener("DOMContentLoaded", function() {
     console.log("showswaps m = "+m)
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
-  }*/
+  }
+  $("input.org_name").change(function(showswaps));
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
     console.log("onpageshow")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -287,7 +287,7 @@ document.addEventListener("DOMContentLoaded", function() {
     var emails = $('input[class="org_email"]');
     var m = 0;
     for ( var i = 1 ; i < n ; i++ )
-      if ( names[i].value || homepages[i].value !| emails[i]  ) m = i;
+      if ( names[i].value || homepages[i].value || emails[i].value  ) m = i;
     console.log("showswaps m = "+m)
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');$('.swap{{i}}').show();})()" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');$('a.swap{{i}}').show();})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -392,14 +392,13 @@ document.addEventListener("DOMContentLoaded", function() {
     showplusminus(n);
   }
   function showswaps() {
-    console.log("showswaps")
     var n = {{maxlength["organizers"]}};
     var x = $('input[class="org_name"]');
     var m = 0;
     for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
-    console.log("m ="+m)
+    console.log("showswaps m = "+m)
     for ( var i = 1 ; i < n ; i++ )
-      document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
+      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible;' : 'hidden' );
   }
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -291,9 +291,7 @@ document.addEventListener("DOMContentLoaded", function() {
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }
-  $("input.org_name").change(showswaps);
-  $("input.org_homepage").change(showswaps);
-  $("input.org_email").change(showswaps);
+  $("input.org_name").input(showswaps); $("input.org_homepage").input(showswaps); $("input.org_email").input(showswaps);
   function swapv(a,b) {
     var x = $('input[name="'+a+'"]')[0].value;
     $('input[name="'+a+'"]')[0].value = $('input[name="'+b+'"]')[0].value;

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -286,17 +286,14 @@ document.addEventListener("DOMContentLoaded", function() {
     var homepages = $('input[class="org_homepage"]');
     var emails = $('input[class="org_email"]');
     var m = 0;
-    for ( var i = 1 ; i < n ; i++ ) {
+    for ( var i = 1 ; i < n ; i++ )
       if ( names[i].value || homepages[i].value || emails[i].value  ) m = i;
-      console.log("names"+i+"="+(names[i].value?"true":"false"));
-      console.log("homepages"+i+"="+(homepages[i].value?"true":"false"));
-      console.log("emails"+i+"="+(emails[i].value?"true":"false"));
-      console.log("showswaps m = "+m)
-    }
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }
   $("input.org_name").change(showswaps);
+  $("input.org_homepage").change(showswaps);
+  $("input.org_email").change(showswaps);
   function swapv(a,b) {
     var x = $('input[name="'+a+'"]')[0].value;
     $('input[name="'+a+'"]')[0].value = $('input[name="'+b+'"]')[0].value;

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -382,6 +382,7 @@ document.addEventListener("DOMContentLoaded", function() {
     var n = {{maxlength["organizers"]}};
     var m = 0;
     for ( var i = 1 ; i < n ; i++ )
+      console.log('org_name'+i)
       if ( document.getElementById('org_name'+i).value != '' ) m = i;
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -198,7 +198,6 @@
         <tr>
           {% if i > 0 %}
             <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
-            <script>function showswap{{i}}() { $('.swap{{i}}').show(); }</script>
           {% else %}
             <td></td>
           {% endif %}
@@ -221,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="showswap{{i}}();" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){$('.swap{{i}}').show();})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -286,9 +286,13 @@ document.addEventListener("DOMContentLoaded", function() {
     var homepages = $('input[class="org_homepage"]');
     var emails = $('input[class="org_email"]');
     var m = 0;
-    for ( var i = 1 ; i < n ; i++ )
+    for ( var i = 1 ; i < n ; i++ ) {
       if ( names[i].value || homepages[i].value || emails[i].value  ) m = i;
-    console.log("showswaps m = "+m)
+      console.log("names"+i+"="+(names[i].value?"true":"false"));
+      console.log("homepages"+i+"="+(homepages[i].value?"true":"false"));
+      console.log("emails"+i+"="+(emails[i].value?"true":"false"));
+      console.log("showswaps m = "+m)
+    }
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
   }

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -197,7 +197,7 @@
         {% for i in range(maxlength["organizers"]) %}
         <tr>
           {% if i > 0 %}
-            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" id="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
+            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a id="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
           {% else %}
             <td></td>
           {% endif %}
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');document.getElementById('swap{{i}}').style.visibility='visible';})()" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){document.getElementById('swap{{i}}').style.visibility='visible';})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
@@ -292,8 +292,8 @@ document.addEventListener("DOMContentLoaded", function() {
     $('input[name="'+b+'"]')[0].checked = x;
     x = $('input[name="'+a+'"]')[0].checked;
   }
-  {% for i in range(1,(seminar.organizers | length)) %}
-    $("a.swap{{i}}").click(function(e){
+  {% for i in range(1,maxlength["organizers"]) %}
+    document.getElementById('swap{{i}}').click(function(e){
       e.preventDefault();
       swapv("org_name{{i-1}}","org_name{{i}}");
       swapv("org_homepage{{i-1}}","org_homepage{{i}}");

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -198,7 +198,6 @@
         <tr>
           {% if i > 0 %}
             <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px; {% if i >= (seminar.organizers | length) %}visibility:hidden;{% endif %}"><a class="swap{{i}}" href="#"><font size="+1">&#x2B0D;</font></a></td>
-            <script>function showswap{{i}}() { if ( $('.swap{{i}}').show(); }</script>
           {% else %}
             <td></td>
           {% endif %}
@@ -220,8 +219,7 @@
             <td align="center">
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
-          {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="showswap{{i}}();" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){$('.swap{{i}}').show();})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -222,16 +222,15 @@
             </td>
           {% else %}
 <script type="text/javascript">
-function showswaps() {
-  console.log("showswaps")
-  var n = {{maxlength["organizers"]}};
-  var x = $('input[class="org_name"]');
-  var m = 0;
-  for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
-  console.log("m ="+m)
-  for ( var i = 1 ; i < n ; i++ )
-    document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
-}
+  function showswaps() {
+    var n = {{maxlength["organizers"]}};
+    var x = $('input[class="org_name"]');
+    var m = 0;
+    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
+    console.log("showswaps m = "+m)
+    for ( var i = 1 ; i < n ; i++ )
+      document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
+  }
 </script>
             <td><input class="org_name" name="org_name{{i}}" style="width:180px;" onchange="showswaps();"/></td>
             <td><input class="org_homepage" name="org_homepage{{i}}" style="width:220px;" /></td>
@@ -391,7 +390,7 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  function showswaps() {
+  /*function showswaps() {
     var n = {{maxlength["organizers"]}};
     var x = $('input[class="org_name"]');
     var m = 0;
@@ -399,7 +398,7 @@ document.addEventListener("DOMContentLoaded", function() {
     console.log("showswaps m = "+m)
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );
-  }
+  }*/
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
     console.log("onpageshow")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -395,7 +395,6 @@ document.addEventListener("DOMContentLoaded", function() {
   }
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
-    console.log("onpageshow")
     showswaps()
     showslots()
   };

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -203,28 +203,28 @@
           {% endif %}
           {% if i < (seminar.organizers | length) %}
             <td>
-              <input name="org_name{{i}}" value="{{ seminar.organizers[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
+              <input class="org" name="org_name{{i}}" value="{{ seminar.organizers[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
             </td>
             <td>
-              <input name="org_homepage{{i}}" value="{{ seminar.organizers[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
+              <input class="org" name="org_homepage{{i}}" value="{{ seminar.organizers[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
             </td>
             <td>
-              <input name="org_email{{i}}" value="{{ seminar.organizers[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
+              <input class="org" name="org_email{{i}}" value="{{ seminar.organizers[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
             </td>
             <td align="center">
               {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}
               {# but it is displayed in a column labeleled "organizer" so it is checked when curator is false #}
-              <input type="checkbox" name="org_curator{{i}}" value="yes" {% if not seminar.organizers[i].get("curator") %}checked{% endif %} />
+              <input type="checkbox" class="org" name="org_curator{{i}}" value="yes" {% if not seminar.organizers[i].get("curator") %}checked{% endif %} />
             </td>
             <td align="center">
-              <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
+              <input type="checkbox" class="org" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){document.getElementById('swap{{i}}').style.visibility='visible';})()" /></td>
-            <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
-            <td><input name="org_email{{i}}" style="width:220px;" /></td>
-            <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
-            <td align="center"><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
+            <td><input class="org" name="org_name{{i}}" style="width:180px;" /></td>
+            <td><input class="org" name="org_homepage{{i}}" style="width:220px;" /></td>
+            <td><input class="org" name="org_email{{i}}" style="width:220px;" /></td>
+            <td align="center"><input type="checkbox" class="org" name="org_curator{{i}}" value="yes" /></td>
+            <td align="center"><input type="checkbox" class="org" name="org_display{{i}}" value="yes" /></td>
           {% endif %}
         </tr>
         {% endfor %}
@@ -378,8 +378,19 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  // Make sure showslots gets called whenever the page is shown, including via the back button
+  function showswaps() {
+    var n = {{maxlength["organizers"]}};
+    var m = 0;
+    for ( var i = 1 ; i < n ; i++ )
+      if ( document.getElementById('org_name'+i).value != '' ) m = i;
+    for ( var i = 1 ; i < n ; i++ )
+      document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
+  }
+  $('input[class="org"]').change(showswaps);
+  $('input[class="org"]').change(showswaps);
+  // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
+    showswaps()
     showslots()
   };
 });

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){$('.swap{{i}}').show();})()" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');$('.swap{{i}}').show();})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -1,16 +1,5 @@
 {% extends "homepage.html" %}
-<script type="text/javascript">
-function showswaps() {
-  console.log("showswaps")
-  var n = {{maxlength["organizers"]}};
-  var x = $('input[class="org_name"]');
-  var m = 0;
-  for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
-  console.log("m ="+m)
-  for ( var i = 1 ; i < n ; i++ )
-    document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
-}
-</script>
+
 {% block content %}
 
   {% if lock %}
@@ -232,6 +221,18 @@ function showswaps() {
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
+<script type="text/javascript">
+function showswaps() {
+  console.log("showswaps")
+  var n = {{maxlength["organizers"]}};
+  var x = $('input[class="org_name"]');
+  var m = 0;
+  for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
+  console.log("m ="+m)
+  for ( var i = 1 ; i < n ; i++ )
+    document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
+}
+</script>
             <td><input class="org_name" name="org_name{{i}}" style="width:180px;" onchange="showswaps();"/></td>
             <td><input class="org_homepage" name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input class="org_email" name="org_email{{i}}" style="width:220px;" /></td>
@@ -390,7 +391,16 @@ document.addEventListener("DOMContentLoaded", function() {
     if ( document.getElementById("frequency").value == 0 ) $('.times').hide(); else $('.times').show(); 
     showplusminus(n);
   }
-  $('input[class="org_name"]').change(showswaps);
+  function showswaps() {
+    console.log("showswaps")
+    var n = {{maxlength["organizers"]}};
+    var x = $('input[class="org_name"]');
+    var m = 0;
+    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
+    console.log("m ="+m)
+    for ( var i = 1 ; i < n ; i++ )
+      document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
+  }
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
     console.log("onpageshow")

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -197,7 +197,7 @@
         {% for i in range(maxlength["organizers"]) %}
         <tr>
           {% if i > 0 %}
-            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
+            <td style="padding-right:0px; padding-top:0px; position:relative; top:-15px;"><a class="swap{{i}}" id="swap{{i}}" {% if i >= (seminar.organizers | length) %}style="visibility:hidden;"{% endif %} href="#"><font size="+1">&#x2B0D;</font></a></td>
           {% else %}
             <td></td>
           {% endif %}
@@ -220,7 +220,7 @@
               <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');$('a.swap{{i}}').show();})()" /></td>
+            <td><input name="org_name{{i}}" style="width:180px;" onchange="(function(){ alert('hi');document.getElementById('show{{i}}').style.visibility='visible';})()" /></td>
             <td><input name="org_homepage{{i}}" style="width:220px;" /></td>
             <td><input name="org_email{{i}}" style="width:220px;" /></td>
             <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -282,9 +282,12 @@ document.addEventListener("DOMContentLoaded", function() {
   {{ prevent_unsaved() }}
   function showswaps() {
     var n = {{maxlength["organizers"]}};
-    var x = $('input[class="org_name"]');
+    var names = $('input[class="org_name"]');
+    var homepages = $('input[class="org_homepage"]');
+    var emails = $('input[class="org_email"]');
     var m = 0;
-    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
+    for ( var i = 1 ; i < n ; i++ )
+      if ( names[i].value || homepages[i].value !| emails[i]  ) m = i;
     console.log("showswaps m = "+m)
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).style.visibility = ( i <= m ? 'visible' : 'hidden' );

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -203,28 +203,28 @@
           {% endif %}
           {% if i < (seminar.organizers | length) %}
             <td>
-              <input class="org" name="org_name{{i}}" value="{{ seminar.organizers[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
+              <input class="org_name" name="org_name{{i}}" value="{{ seminar.organizers[i].get('name') | blanknone }}" style="width:180px" maxlength="{{ maxlength['name'] }}" />
             </td>
             <td>
-              <input class="org" name="org_homepage{{i}}" value="{{ seminar.organizers[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
+              <input class="org_homepage" name="org_homepage{{i}}" value="{{ seminar.organizers[i].get('homepage') | blanknone }}" style="width:220px" maxlength="{{ maxlength['homepage'] }}" />
             </td>
             <td>
-              <input class="org" name="org_email{{i}}" value="{{ seminar.organizers[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
+              <input class="org_email" name="org_email{{i}}" value="{{ seminar.organizers[i].get('email') | blanknone }}" style="width:220px" maxlength="{{ maxlength['email'] }}"/>
             </td>
             <td align="center">
               {# Note the checkbox is called org_curator because it comes from the curator column in seminar organizers, #}
               {# but it is displayed in a column labeleled "organizer" so it is checked when curator is false #}
-              <input type="checkbox" class="org" name="org_curator{{i}}" value="yes" {% if not seminar.organizers[i].get("curator") %}checked{% endif %} />
+              <input type="checkbox" name="org_curator{{i}}" value="yes" {% if not seminar.organizers[i].get("curator") %}checked{% endif %} />
             </td>
             <td align="center">
-              <input type="checkbox" class="org" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
+              <input type="checkbox" name="org_display{{i}}" value="yes" {% if seminar.organizers[i].get("display") %}checked{% endif %} />
             </td>
           {% else %}
-            <td><input class="org" name="org_name{{i}}" style="width:180px;" /></td>
-            <td><input class="org" name="org_homepage{{i}}" style="width:220px;" /></td>
-            <td><input class="org" name="org_email{{i}}" style="width:220px;" /></td>
-            <td align="center"><input type="checkbox" class="org" name="org_curator{{i}}" value="yes" /></td>
-            <td align="center"><input type="checkbox" class="org" name="org_display{{i}}" value="yes" /></td>
+            <td><input class="org_name" name="org_name{{i}}" style="width:180px;" /></td>
+            <td><input class="org_homepage" name="org_homepage{{i}}" style="width:220px;" /></td>
+            <td><input class="org_email" name="org_email{{i}}" style="width:220px;" /></td>
+            <td align="center"><input type="checkbox" name="org_curator{{i}}" value="yes" /></td>
+            <td align="center"><input type="checkbox" name="org_display{{i}}" value="yes" /></td>
           {% endif %}
         </tr>
         {% endfor %}
@@ -380,15 +380,13 @@ document.addEventListener("DOMContentLoaded", function() {
   }
   function showswaps() {
     var n = {{maxlength["organizers"]}};
+    var x = $('input[class="org_name"]');
     var m = 0;
-    for ( var i = 1 ; i < n ; i++ )
-      console.log('org_name'+i)
-      if ( document.getElementById('org_name'+i).value != '' ) m = i;
+    for ( var i = 1 ; i < n ; i++ ) if ( x[i].value != '' ) m = i;
     for ( var i = 1 ; i < n ; i++ )
       document.getElementById('swap'+i).visibility = ( i <= m ? 'visible;' : 'hidden' );
   }
-  $('input[class="org"]').change(showswaps);
-  $('input[class="org"]').change(showswaps);
+  $('input[class="org_name"]').change(showswaps);
   // Make sure showswaps and showslots gets called whenever the page is shown, including via the back button
   window.onpageshow = function(e) {
     showswaps()


### PR DESCRIPTION
Organizer swap arrows now appear as soon as a value is committed to name, homepage, or email (meaning the user has pressed tab or clicked on another element) rather than only after submitting the form.

I'm not monitoring every keystroke, so the arrows don't show up as soon as you start typing (I could do this, but it seems unnecessary)