### PR TITLE
Tweaks to audience knowls and categories plus pyflake fixes

### DIFF
--- a/seminars/api/example.py
+++ b/seminars/api/example.py
@@ -30,8 +30,9 @@ def search_series_get():
         print("There are %s series in the US/Pacific time zone" % len(results))
 
 def search_series_post():
-    from requests import post
     url = "https://researchseminars.org/api/0/search/series"
+    #FIXME: pyflakes is not happy because url is not referenced
+    #FIXME: not clear what is supposed to happen here, if anything...
 
 def authorization():
     # We suggest keeping your api token in a separate file and adding it to your .gitignore

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -481,18 +481,18 @@ level:
   contents: |
     Series and talks may be distinguished by their target audience as follows:
     <ul>
-      <li><b>Research seminar</b>:
-          Researchers in a particular topic or subtopic.</li>
-      <li><b>Colloquium</b>:
-          A general academic audience in a subject area.</li>
-      <li><b>Learning seminar</b>:
-          Students and researchers interested in learning the details of a particular result or subtopic.</li>
-      <li><b>Advanced Learning seminar</b>:
-          Graduate students and researchers interested in learning a particular result or subtopic that requires significant background.</li>
+      <li><b>Toipic researchers</b>:
+          researchers in a particular topic or subtopic.</li>
+      <li><b>Subject reserchers and students</b>:
+          academic audience in a subject area (a colloquium, for example).</li>
+      <li><b>Topic learners</b>:
+          students and researchers interested in learning the details of a particular result or subtopic (a learning seminar for example).</li>
+      <li><b>Advanced topic learners</b>:
+          students and researchers interested in learning the details of a particular result or subtopic that requires significant background in the topic.</li>
       <li><b>Undergraduate seminar</b>:
-          Primarily undergraduates.</li>
-      <li><b>General public</b>:
-          Members of the general public with an academic interest.</li>
+          primarily undergraduates.</li>
+      <li><b>General audience</b>:
+          academic audience and members of the public with an academic interest (a public lecture, for example).</li>
     </ul>
 hidden:
   title: Hide

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -486,13 +486,13 @@ level:
       <li><b>Subject area audience</b>:
           academic audience within a department or subject area (a colloquium, for example).</li>
       <li><b>Learners</b>:
-          researchers and students interested in learning the details of a particular result or subtopic (a learning seminar for example).</li>
+          researchers and students interested in learning the details of a particular result or subtopic.</li>
       <li><b>Advanced learners</b>:
           researchers interested in learning the details of a particular result or subtopic that requires significant background in the topic.</li>
       <li><b>Undergraduates</b>:
-          primarily undergraduates.</li>
+          undergraduate students.</li>
       <li><b>General audience</b>:
-          general academic audience and members of the public with an academic interest (a public lecture, for example).</li>
+          general academic audience and members of the public with an academic interest.</li>
     </ul>
 hidden:
   title: Hide

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -481,18 +481,18 @@ level:
   contents: |
     Series and talks may be distinguished by their target audience as follows:
     <ul>
-      <li><b>Toipic researchers</b>:
+      <li><b>Researchers</b>:
           researchers in a particular topic or subtopic.</li>
-      <li><b>Subject reserchers and students</b>:
-          academic audience in a subject area (a colloquium, for example).</li>
-      <li><b>Topic learners</b>:
-          students and researchers interested in learning the details of a particular result or subtopic (a learning seminar for example).</li>
-      <li><b>Advanced topic learners</b>:
-          students and researchers interested in learning the details of a particular result or subtopic that requires significant background in the topic.</li>
-      <li><b>Undergraduate seminar</b>:
+      <li><b>Subject area audience</b>:
+          academic audience within a department or subject area (a colloquium, for example).</li>
+      <li><b>Learners</b>:
+          researchers and students interested in learning the details of a particular result or subtopic (a learning seminar for example).</li>
+      <li><b>Advanced learners</b>:
+          researchers interested in learning the details of a particular result or subtopic that requires significant background in the topic.</li>
+      <li><b>Undergraduates</b>:
           primarily undergraduates.</li>
       <li><b>General audience</b>:
-          academic audience and members of the public with an academic interest (a public lecture, for example).</li>
+          general academic audience and members of the public with an academic interest (a public lecture, for example).</li>
     </ul>
 hidden:
   title: Hide

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -65,12 +65,12 @@ visibility_options = [
 ]
 
 level_options = [
-    (0, "research seminar"),
-    (1, "colloquium"),
-    (2, "learning seminar"),
-    (3, "advanced learning seminar"),
-    (4, "undergraduate seminar"),
-    (5, "general public"),
+    (0, "topic researchers"),
+    (1, "subject researchers and students"),
+    (2, "topic learners"),
+    (3, "advanced topic learners"),
+    (4, "undergraduate students"),
+    (5, "general audience"),
 ]
 
 class WebSeminar(object):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -64,8 +64,8 @@ visibility_options = [
 ]
 
 level_options = [
-    (0, "topic researchers"),
-    (1, "subject researchers and students"),
+    (0, "researchers"),
+    (1, "subject area audience"),
     (2, "topic learners"),
     (3, "advanced topic learners"),
     (4, "undergraduate students"),

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -26,7 +26,6 @@ import pytz
 from collections import defaultdict
 from datetime import datetime
 from lmfdb.logger import critical
-from psycopg2.sql import Placeholder
 
 import urllib.parse
 

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -28,7 +28,6 @@ import urllib.parse
 from icalendar import Event
 from lmfdb.logger import critical
 from datetime import datetime, timedelta
-from psycopg2.sql import Placeholder
 import re
 
 class WebTalk(object):
@@ -833,7 +832,7 @@ def talks_search(*args, **kwds):
     else:
         table = db.talks
     more = kwds.get("more", False)
-    return search_distinct(db.talks, _selecter, _counter, _iterator(seminar_dict, objects=objects, more=more), *args, **kwds)
+    return search_distinct(table, _selecter, _counter, _iterator(seminar_dict, objects=objects, more=more), *args, **kwds)
 
 
 def talks_lucky(*args, **kwds):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -15,6 +15,7 @@ from psycopg2.sql import SQL
 from seminars import db
 from six import string_types
 from urllib.parse import urlparse, urlencode
+from psycopg2.sql import Placeholder
 import pytz
 import re
 from lmfdb.backend.searchtable import PostgresSearchTable


### PR DESCRIPTION
In addition to changing the audience knowls this PR fixes several (but not all) pyflakes complaints, including one that appears to have been a bug in talks_search (the variable table was set but not passed into search_distinct).  There remains an outstanding pyflakes complaint about the unused variable url in api/example.py in the function search_series_post (this function simply sets a variable, does nothing with it, and does not return a value, it's not clear what it is supposed to do, if anything.