### PR TITLE
Add validation of talks and speakers, fix several bugs

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -853,7 +853,6 @@ def save_talk():
     if errmsgs:
         return show_input_errors(errmsgs)
     else: # to make it obvious that these two statements should be together
-        print("Creating new talk with data = " + str(data))
         new_version = WebTalk(talk.seminar_id, data=data)
 
     sanity_check_times(new_version.start_time, new_version.end_time)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -893,11 +893,14 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
     tz = pytz.timezone(tz)
 
     for col in db.talks.search_cols:
+        print("processing  column "+ col)
         if col in data:
+            print("in data")
             continue
         # For the API, we want to carry over unspecified columns from the previous data
         if col not in raw_data:
             data[col] = getattr(talk, col, None)
+            print("set to None!")
             continue
         typ = db.talks.col_type[col]
         try:
@@ -906,6 +909,7 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
             data[col] = process_user_input(val, col, typ, tz)
         except Exception as err:  # should only be ValueError's but let's be cautious
             errmsgs.append(format_input_errmsg(err, val, col))
+        print("value =" + str(data[col]))
     if not data["speaker"]:
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -894,14 +894,11 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
     tz = pytz.timezone(tz)
 
     for col in db.talks.search_cols:
-        print("processing  column "+ col)
         if col in data:
-            print("in data")
             continue
         # For the API, we want to carry over unspecified columns from the previous data
         if col not in raw_data:
             data[col] = getattr(talk, col, None)
-            print("set to None!")
             continue
         typ = db.talks.col_type[col]
         try:
@@ -910,7 +907,6 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
             data[col] = process_user_input(val, col, typ, tz)
         except Exception as err:  # should only be ValueError's but let's be cautious
             errmsgs.append(format_input_errmsg(err, val, col))
-        print("value =" + str(data[col]))
     if not data["speaker"]:
         errmsgs.append("Speaker name cannot be blank -- use TBA if speaker not chosen.")
     if data["start_time"] is None or data["end_time"] is None:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -853,6 +853,7 @@ def save_talk():
     if errmsgs:
         return show_input_errors(errmsgs)
     else: # to make it obvious that these two statements should be together
+        print("Creating new talk with data = " + str(data))
         new_version = WebTalk(talk.seminar_id, data=data)
 
     sanity_check_times(new_version.start_time, new_version.end_time)

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -8,7 +8,7 @@
   <input type="hidden" name="new" value="{{ 'yes' if talk.new else 'no' }}"/>
   <input type="hidden" name="token" value="{{ talk.token }}"/>
   <input type="hidden" name="topics" value="{{ talk.topics | safe }}"/>
-  <input type="hidden" name="language" value="{{ seminar.language  | safe }}"/>
+  <input type="hidden" name="language" value="{{ talk.language  | safe }}"/>
   This talk is part of <a href="{{ url_for('show_seminar', shortname=talk.seminar_id) }}">{{ seminar.name | blanknone }}</a>.
   <button class="save" type="submit" value="save" onclick="unsaved = false;" style="float: right;">Save changes</button>
 
@@ -63,7 +63,7 @@
       <td>
         <select name="audience" style="width:610px;">
           {% for opt in options["audience"] %}
-            <option value="{{opt[0]}}" {% if seminar.audience == opt[0] %}selected{% endif %}>{{opt[1]}}</option>
+            <option value="{{opt[0]}}" {% if talk.audience == opt[0] %}selected{% endif %}>{{opt[1]}}</option>
           {% endfor %}
         </select>
       </td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -61,7 +61,7 @@
     <tr>
       <td>{{ ASTKNOWL("audience") }}</td>
       <td>
-        <select name="level" style="width:610px;">
+        <select name="audience" style="width:610px;">
           {% for opt in options["audience"] %}
             <option value="{{opt[0]}}" {% if seminar.audience == opt[0] %}selected{% endif %}>{{opt[1]}}</option>
           {% endfor %}

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -143,7 +143,6 @@ def parse_slides(info, query):
 
 def parse_paper(info, query):
     v = info.get("paper")
-    print("paper", info)
     if v == "1":
         query["paper_link"] = {"$ne": ''}
 

--- a/seminars/language.py
+++ b/seminars/language.py
@@ -52,7 +52,6 @@ class Languages(object):
             code = "language"
             onchange = 'toggleFilters(this.id);'
             value = 1 if request.cookies.get('filter_language', '-1') == '1' else -1
-            print("filter_language", value)
         else:
             onchange = 'toggleLanguage(this.id);'
             value = 1 if code in request.cookies.get("languages", "").split(",") else -1

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -187,7 +187,7 @@ class WebSeminar(object):
                     sts = False
                     log_error("column %s is None for conference %s" % (col, self.shortname))
         else:
-            if gettatr(self, "frequency") is None:
+            if getatr(self, "frequency") is None:
                 sts = False
                 log_error("column frequency is None for seminar series %s" % self.shortname)
             elif self.frequency:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -207,7 +207,7 @@ class WebSeminar(object):
                 if self.access_registration is None:
                     sts = False
                     log_error("access_registration is None for online series %s with access_control == 5" % self.shortname)
-    return sts        
+        return sts        
 
     def cleanse(self):
         """

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -178,7 +178,9 @@ class WebSeminar(object):
         This function is used to ensure backward compatibility across changes to the schema and/or validation
         This is the only place where columns we plan to drop should be referenced 
         """
-        critical("test message")
+        import app
+        
+        app.logger.error("test message")
         for col in required_seminar_columns:
             if getattr(self, col) is None:
                 critical("column %s is None for series %s" % (col, self.shortname))

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -187,10 +187,14 @@ class WebSeminar(object):
                     sts = False
                     log_error("column %s is None for conference %s" % (col, self.shortname))
         else:
-            for col in ["frequency", "weekdays", "time_slots"]:
-                if getattr(self, col) is None:
-                    sts = False
-                    log_error("column %s is None for seminar series %s" % (col, self.shortname))
+            if gettatr(self, "frequency") is None:
+                sts = False
+                log_error("column frequency is None for seminar series %s" % self.shortname)
+            elif self.frequency:
+                for col in ["weekdays", "time_slots"]:
+                    if getattr(self, col) is None:
+                        sts = False
+                        log_error("column %s is None for seminar series %s" % (col, self.shortname))
         if self.online:
             if self.access_control is None:
                 sts = False

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -25,7 +25,6 @@ from psycopg2.sql import SQL
 import pytz
 from collections import defaultdict
 from datetime import datetime
-from lmfdb.logger import critical
 
 import urllib.parse
 
@@ -137,6 +136,8 @@ class WebSeminar(object):
                 elif typ == "date":
                     setattr(self, key, None)
                 else:
+                    from lmfdb.logger import critical
+                    # don't write these to the flasklog
                     critical("Need to update seminar code to account for schema change key=%s" % key)
                     setattr(self, key, None)
             if organizers is None:
@@ -179,7 +180,6 @@ class WebSeminar(object):
         This function is used to ensure backward compatibility across changes to the schema and/or validation
         This is the only place where columns we plan to drop should be referenced 
         """
-        log_error("test message")
         for col in required_seminar_columns:
             if getattr(self, col) is None:
                 log_error("column %s is None for series %s" % (col, self.shortname))

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -84,6 +84,16 @@ required_seminar_columns = [
     "topics",
 ]
 
+optional_seminar_text_columns = [
+    "access_hint",
+    "access_registration",
+    "comments",
+    "homepage",
+    "live_link",
+    "room",
+]
+
+
 class WebSeminar(object):
     def __init__(
         self, shortname, data=None, organizers=None, editing=False, showing=False, saving=False, deleted=False,  user=None,
@@ -218,6 +228,9 @@ class WebSeminar(object):
         This function is used to ensure backward compatibility across changes to the schema and/or validation
         This is the only place where columns we plan to drop should be referenced 
         """
+        for col in optional_seminar_text_columns:
+            if getattr(self, col) is None:
+                setattr(self, col, "")
         self.validate()
 
     def visible(self, user=None):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -14,6 +14,7 @@ from seminars.utils import (
     show_input_errors,
     weekdays,
     sanitized_table,
+    log_error,
 )
 from seminars.topic import topic_dag
 from seminars.toggle import toggle
@@ -178,32 +179,30 @@ class WebSeminar(object):
         This function is used to ensure backward compatibility across changes to the schema and/or validation
         This is the only place where columns we plan to drop should be referenced 
         """
-        from seminars.app import app
-
-        app.logger.error("test message")
+        log_error("test message")
         for col in required_seminar_columns:
             if getattr(self, col) is None:
-                critical("column %s is None for series %s" % (col, self.shortname))
+                log_error("column %s is None for series %s" % (col, self.shortname))
         if self.is_conference:
             for col in ["start_date", "end_date", "per_day"]:
                 if getattr(self, col) is None:
-                    critical("column %s is None for conference %s" % (col, self.shortname))
+                    log_error("column %s is None for conference %s" % (col, self.shortname))
         else:
             for col in ["frequency", "weekdays", "time_slots"]:
                 if getattr(self, col) is None:
-                    critical("column %s is None for seminar series %s" % (col, self.shortname))
+                    log_error("column %s is None for seminar series %s" % (col, self.shortname))
         if self.online:
             if self.access_control is None:
-                critical("access_control is None for online series %s" % self.shortname)
+                log_error("access_control is None for online series %s" % self.shortname)
             elif self.access_control == 1:
                 if self.access_time is None:
-                    critical("access_time is None for online series %s with access_control == 1" % self.shortname)
+                    log_error("access_time is None for online series %s with access_control == 1" % self.shortname)
             elif self.access_control == 2:
                 if self.access_hint is None:
-                    critical("access_hint is None for online series %s with access_control == 2" % self.shortname)
+                    log_error("access_hint is None for online series %s with access_control == 2" % self.shortname)
             elif self.access_control == 5:
                 if self.access_registration is None:
-                    critical("access_registration is None for online series %s with access_control == 5" % self.shortname)
+                    log_error("access_registration is None for online series %s with access_control == 5" % self.shortname)
         pass
 
     def visible(self, user=None):

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -178,8 +178,8 @@ class WebSeminar(object):
         This function is used to ensure backward compatibility across changes to the schema and/or validation
         This is the only place where columns we plan to drop should be referenced 
         """
-        import app
-        
+        from seminars.app import app
+
         app.logger.error("test message")
         for col in required_seminar_columns:
             if getattr(self, col) is None:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -187,7 +187,7 @@ class WebSeminar(object):
                 if getattr(self, col) is None:
                     critical("column %s is None for conference %s" % (col, self.shortname))
         else:
-            for col in ["frequency", "weekday", "time_slots"]:
+            for col in ["frequency", "weekdays", "time_slots"]:
                 if getattr(self, col) is None:
                     critical("column %s is None for seminar series %s" % (col, self.shortname))
         if self.online:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -187,7 +187,7 @@ class WebSeminar(object):
                     sts = False
                     log_error("column %s is None for conference %s" % (col, self.shortname))
         else:
-            if getatr(self, "frequency") is None:
+            if getattr(self, "frequency") is None:
                 sts = False
                 log_error("column frequency is None for seminar series %s" % self.shortname)
             elif self.frequency:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -89,7 +89,6 @@ class WebTalk(object):
             self.timezone = seminar.timezone
             for key, typ in db.talks.col_type.items():
                 if key == "id" or hasattr(self, key):
-                    print("skipping col %s" % key)
                     continue
                 elif db.seminars.col_type.get(key) == typ and getattr(seminar, key, None):
                     # carry over from seminar, but not comments

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -107,7 +107,7 @@ class WebTalk(object):
                 if key == "id" or hasattr(self, key):
                     continue
                 if key in inherited_talk_columns:
-                    settattr(self, key, getattr(seminar, key))
+                    setattr(self, key, getattr(seminar, key))
                 elif typ == "text":
                     setattr(self, key, "")
                 elif typ == "text[]":

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -44,6 +44,22 @@ required_talk_columns = [
     "topics",
 ]
 
+inherited_talk_columns = [
+    "access_control",
+    "access_time",
+    "access_hint",
+    "access_registration",
+    "audience",
+    "display",
+    "language",
+    "live_link",
+    "online",
+    "room",
+    "stream_link",
+    "timezone",
+    "topics",
+]
+
 
 
 # the columns speaker, speaker_email, speaker_homepage, and speaker_affiliation are
@@ -90,10 +106,8 @@ class WebTalk(object):
             for key, typ in db.talks.col_type.items():
                 if key == "id" or hasattr(self, key):
                     continue
-                elif db.seminars.col_type.get(key) == typ and getattr(seminar, key, None):
-                    # carry over from seminar, but not comments
-                    setattr(self, key, getattr(seminar, key) if key != "comments" else "")
-                    print("talk inherited %s = %s from seminar"%(key,getattr(self,key)))
+                if key in inherited_talk_columns:
+                    settattr(self, key, getattr(seminar, key))
                 elif typ == "text":
                     setattr(self, key, "")
                 elif typ == "text[]":

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -105,7 +105,7 @@ class WebTalk(object):
             self.deleted_with_seminar = False
             self.hidden = False
             for key, typ in db.talks.col_type.items():
-                if key in ["id", "edited_by", "edited_at", "start_time", "end_time"] or hasattr(self, key):
+                if key == "id" or hasattr(self, key):
                     continue
                 if key in inherited_talk_columns:
                     setattr(self, key, getattr(seminar, key))
@@ -114,7 +114,9 @@ class WebTalk(object):
                 elif typ == "text[]":
                     setattr(self, key, [])
                 else:
-                    critical("Need to update talk code to account for schema change key=%s" % key)
+                    # don't complain about columns we know are going to be set later
+                    if not key in ["edited_by", "edited_at", "start_time", "end_time"]:
+                        critical("Need to update talk code to account for schema change key=%s" % key)
                     setattr(self, key, None)
         else:
             # The output from psycopg2 seems to always be given in the server's time zone
@@ -125,7 +127,7 @@ class WebTalk(object):
                 if data.get("end_time"):
                     data["end_time"] = adapt_datetime(data["end_time"], tz)
             self.__dict__.update(data)
-        self.cleanse()
+            self.cleanse()
 
     def __repr__(self):
         title = self.title if self.title else "TBA"
@@ -159,7 +161,6 @@ class WebTalk(object):
         This is the only place where columns we plan to drop should be referenced 
         """
         self.validate()
-        pass
 
     def visible(self):
         """

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -78,6 +78,7 @@ class WebTalk(object):
         saving=False,
         deleted=False,
     ):
+        print("call to WebTalk with editing = %s and data = " %(editing, data))
         if data is None and not editing:
             data = talks_lookup(seminar_id, seminar_ctr, include_deleted=deleted)
             if data is None:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -356,10 +356,10 @@ class WebTalk(object):
         speakers = [s.strip() for s in self.speaker.split(SPEAKER_DELIMITER)]
         if not speakers:
             return ''
-        homepages = [s.strip() for s in self.speaker_homepage.split(SPEAKER_DELIMITER)]
+        homepages = [s.strip() for s in self.speaker_homepage.split(SPEAKER_DELIMITER)] if self.speaker_homepage else []
         for i in range(len(speakers)-len(homepages)):
             homepages.append('')
-        affiliations = [s.strip() for s in self.speaker_affiliation.split(SPEAKER_DELIMITER)] if affiliation else []
+        affiliations = [s.strip() for s in self.speaker_affiliation.split(SPEAKER_DELIMITER)] if affiliation and self.speaker_affiliation else []
         for i in range(len(speakers)-len(affiliations)):
             affiliations.append('')
         items = []

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -37,7 +37,6 @@ required_talk_columns = [
     "end_time",
     "online",
     "language",
-    "name",
     "seminar_id",
     "seminar_ctr",
     "start_time",

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -94,7 +94,7 @@ class WebTalk(object):
             seminar = WebSeminar(seminar_id, deleted=deleted)
         self.seminar = seminar
         self.new = data is None
-        self.deleted=False
+        self.deleted=False #FIXME: why is this here
         if self.new:
             self.seminar_id = seminar_id
             self.seminar_ctr = None
@@ -103,8 +103,10 @@ class WebTalk(object):
             self.online = getattr(seminar, "online", bool(seminar.live_link))
             self.by_api = False # reset by API code if needed
             self.timezone = seminar.timezone
+            self.deleted = False
+            self.deleted_with_seminar = False
             for key, typ in db.talks.col_type.items():
-                if key == "id" or hasattr(self, key):
+                if key in ["id", "edited_by", "edited_at"] or hasattr(self, key):
                     continue
                 if key in inherited_talk_columns:
                     setattr(self, key, getattr(seminar, key))

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -313,23 +313,19 @@ class WebTalk(object):
     def show_speaker(self, raw=False, affiliation=True):
         # As part of a list
         speakers = [s.strip() for s in self.speaker.split(SPEAKER_DELIMITER)]
-        print(speakers)
         if not speakers:
             return ''
         homepages = [s.strip() for s in self.speaker_homepage.split(SPEAKER_DELIMITER)]
         for i in range(len(speakers)-len(homepages)):
             homepages.append('')
-        print(homepages)
         affiliations = [s.strip() for s in self.speaker_affiliation.split(SPEAKER_DELIMITER)] if affiliation else []
         for i in range(len(speakers)-len(affiliations)):
             affiliations.append('')
-        print(affiliations)
         items = []
         for i in range(len(speakers)):
             item = '<a href="%s">%s</a>' % (homepages[i],speakers[i]) if homepages[i] and not raw else speakers[i]
             item += (" (%s)" % affiliations[i]) if affiliations[i] else ''
             items.append(item)
-        print(items)
         return comma_list(items)
 
     def show_speaker_and_seminar(self, external=False):

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -60,6 +60,24 @@ inherited_talk_columns = [
     "topics",
 ]
 
+optional_talk_text_columns = [
+    "abstract",
+    "access_hint",
+    "access_registration",
+    "comments",
+    "live_link",
+    "room",
+    "paper_link",
+    "slides_link",
+    "speaker",
+    "speaker_affiliation",
+    "speaker_email",
+    "speaker_homepage",
+    "stream_link",
+    "title",
+    "video_link",
+]
+
 # the columns speaker, speaker_email, speaker_homepage, and speaker_affiliation are
 # text strings that may contain delimited lists (which should all have the same length, empty items are OK)
 SPEAKER_DELIMITER = '|'
@@ -97,8 +115,6 @@ class WebTalk(object):
             self.seminar_id = seminar_id
             self.seminar_ctr = None
             self.token = secrets.token_hex(8)
-            self.access_hint = seminar.access_hint
-            self.online = getattr(seminar, "online", bool(seminar.live_link))
             self.by_api = False # reset by API code if needed
             self.timezone = seminar.timezone
             self.deleted = False
@@ -160,6 +176,9 @@ class WebTalk(object):
         This function is used to ensure backward compatibility across changes to the schema and/or validation
         This is the only place where columns we plan to drop should be referenced 
         """
+        for col in optional_talk_text_columns:
+            if getattr(self, col) is None:
+                setattr(self, col, "")
         self.validate()
 
     def visible(self):
@@ -356,10 +375,10 @@ class WebTalk(object):
         speakers = [s.strip() for s in self.speaker.split(SPEAKER_DELIMITER)]
         if not speakers:
             return ''
-        homepages = [s.strip() for s in self.speaker_homepage.split(SPEAKER_DELIMITER)] if self.speaker_homepage else []
+        homepages = [s.strip() for s in self.speaker_homepage.split(SPEAKER_DELIMITER)]
         for i in range(len(speakers)-len(homepages)):
             homepages.append('')
-        affiliations = [s.strip() for s in self.speaker_affiliation.split(SPEAKER_DELIMITER)] if affiliation and self.speaker_affiliation else []
+        affiliations = [s.strip() for s in self.speaker_affiliation.split(SPEAKER_DELIMITER)] if affiliation else []
         for i in range(len(speakers)-len(affiliations)):
             affiliations.append('')
         items = []

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -78,7 +78,6 @@ class WebTalk(object):
         saving=False,
         deleted=False,
     ):
-        print("call to WebTalk with editing = %s and data = %s" %(editing, data))
         if data is None and not editing:
             data = talks_lookup(seminar_id, seminar_ctr, include_deleted=deleted)
             if data is None:
@@ -97,6 +96,10 @@ class WebTalk(object):
         self.new = data is None
         self.deleted=False #FIXME: why is this here
         if self.new:
+            if editing:
+                import traceback
+                print("creating empty talk")
+                print(traceback.format_stack())
             self.seminar_id = seminar_id
             self.seminar_ctr = None
             self.token = secrets.token_hex(8)

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -78,7 +78,7 @@ class WebTalk(object):
         saving=False,
         deleted=False,
     ):
-        print("call to WebTalk with editing = %s and data = " %(editing, data))
+        print("call to WebTalk with editing = %s and data = %" %(editing, data))
         if data is None and not editing:
             data = talks_lookup(seminar_id, seminar_ctr, include_deleted=deleted)
             if data is None:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -78,7 +78,7 @@ class WebTalk(object):
         saving=False,
         deleted=False,
     ):
-        print("call to WebTalk with editing = %s and data = %" %(editing, data))
+        print("call to WebTalk with editing = %s and data = %s" %(editing, data))
         if data is None and not editing:
             data = talks_lookup(seminar_id, seminar_ctr, include_deleted=deleted)
             if data is None:

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -1197,7 +1197,7 @@ button {
 select, select option{
     background: {{color.select_background}};
     font-size: 100%;
-    height: 31px;
+    height: 30px;
 }
 
 body.knowl form button,

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -1163,8 +1163,8 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 
 input, textarea, #topicDAG_selector {
   border: 2px solid {{color.input_border}};
-  font-size: 100%;
-  padding: 6px;
+  font-size: 110%;
+  padding: 3px;
   border-radius: 5px;
 }
 
@@ -1196,8 +1196,8 @@ button {
 
 select, select option{
     background: {{color.select_background}};
-    font-size: 110%;
-    height: 30px;
+    font-size: 100%;
+    height: 31px;
 }
 
 body.knowl form button,

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -1164,7 +1164,7 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 input, textarea, #topicDAG_selector {
   border: 2px solid {{color.input_border}};
   font-size: 100%;
-  padding: 5px;
+  padding: 6px;
   border-radius: 5px;
 }
 

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -1163,8 +1163,8 @@ body.intro #sidebar a.intro { background: {{ color.sidebar_bkg_highlight }}; }
 
 input, textarea, #topicDAG_selector {
   border: 2px solid {{color.input_border}};
-  font-size: 110%;
-  padding: 3px;
+  font-size: 100%;
+  padding: 5px;
   border-radius: 5px;
 }
 

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -237,7 +237,7 @@ def log_error(msg):
     try:
         raise RuntimeError()
     except Exception as err:
-        app.logger.error(traceback.format_stack())
+        app.logger.error('\n'.join(traceback.format_stack()))
         app.logger.error(timestamp() + " seminars application logged error: " + msg)
 
 def pretty_timezone(tz, dest="selecter"):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -236,7 +236,7 @@ def log_error(msg):
     import traceback, sys
     try:
         raise RuntimeError()
-    except Exception, err:
+    except Exception as err:
         app.logger.error(traceback.format_exception_only(sys.exc_info()[0]), err)
         app.logger.error(timestamp() + " seminars application logged error: " + msg)
 

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -237,8 +237,8 @@ def log_error(msg):
     try:
         raise RuntimeError()
     except Exception as err:
-        app.logger.error('\n'.join(traceback.format_stack()))
-        app.logger.error(timestamp() + " seminars application logged error: " + msg)
+        app.logger.error(timestamp() + " ERROR logged: " + traceback.format_stack()[-2])
+        app.logger.error(timestamp() + " ERROR message:  " + msg)
 
 def pretty_timezone(tz, dest="selecter"):
     foo = int(naive_utcoffset(tz).total_seconds())

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -233,11 +233,11 @@ def timestamp():
 
 def log_error(msg):
     from seminars.app import app
-    import traceback, sys
+    import traceback
     try:
         raise RuntimeError()
     except Exception as err:
-        app.logger.error(traceback.format_exception_only(sys.exc_info()[0], err))
+        app.logger.error(traceback.format_stack())
         app.logger.error(timestamp() + " seminars application logged error: " + msg)
 
 def pretty_timezone(tz, dest="selecter"):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -238,7 +238,7 @@ def log_error(msg):
         raise RuntimeError()
     except Exception:
         app.logger.error(traceback.format_exception_only(sys.exc_info()[0]))
-        app.logger.error(timestamp() + " " + msg)
+        app.logger.error(timestamp() + " seminars application logged error: " + msg)
 
 def pretty_timezone(tz, dest="selecter"):
     foo = int(naive_utcoffset(tz).total_seconds())

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -237,7 +237,7 @@ def log_error(msg):
     try:
         raise RuntimeError()
     except Exception as err:
-        app.logger.error(traceback.format_exception_only(sys.exc_info()[0]), err)
+        app.logger.error(traceback.format_exception_only(sys.exc_info()[0], err))
         app.logger.error(timestamp() + " seminars application logged error: " + msg)
 
 def pretty_timezone(tz, dest="selecter"):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -237,7 +237,7 @@ def log_error(msg):
     try:
         raise RuntimeError()
     except Exception as err:
-        app.logger.error(timestamp() + " ERROR logged: " + traceback.format_stack()[-2])
+        app.logger.error(timestamp() + " ERROR logged: " + traceback.format_stack()[-2][:-1])
         app.logger.error(timestamp() + " ERROR message:  " + msg)
 
 def pretty_timezone(tz, dest="selecter"):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -71,6 +71,7 @@ maxlength = {
     'weekdays' : MAX_SLOTS,
 }
 
+
 def comma_list(items):
     """ return list of stringe as list in English (e.g. [Bill] = Bill, [Bill, Ted] = Bill and Ted, [Bill, Ted, Jane] = Bill, Ted, and Jane) """
     if not items:
@@ -229,6 +230,15 @@ def naive_utcoffset(tz):
 def timestamp():
     return "[%s UTC]" % datetime.now(tz=pytz.UTC).strftime("%Y-%m-%d %H:%M:%S")
 
+
+def log_error(msg):
+    from seminars.app import app
+    import traceback, sys
+    try:
+        raise RuntimeError()
+    except Exception:
+        app.logger.error(traceback.format_exception_only(sys.exc_info()[0]))
+        app.logger.error(timestamp() + " " + msg)
 
 def pretty_timezone(tz, dest="selecter"):
     foo = int(naive_utcoffset(tz).total_seconds())

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -236,8 +236,8 @@ def log_error(msg):
     import traceback, sys
     try:
         raise RuntimeError()
-    except Exception:
-        app.logger.error(traceback.format_exception_only(sys.exc_info()[0]))
+    except Exception, err:
+        app.logger.error(traceback.format_exception_only(sys.exc_info()[0]), err)
         app.logger.error(timestamp() + " seminars application logged error: " + msg)
 
 def pretty_timezone(tz, dest="selecter"):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -236,7 +236,7 @@ def log_error(msg):
     import traceback
     try:
         raise RuntimeError()
-    except Exception as err:
+    except Exception:
         app.logger.error(timestamp() + " ERROR logged: " + traceback.format_stack()[-2][:-1])
         app.logger.error(timestamp() + " ERROR message:  " + msg)
 


### PR DESCRIPTION
Fixes bug preventing audience being edited for talks and a couple of other small things.

Adds data validation on all talks and speakers when they are loaded from the database and when they are saved.  Failures will be logged to the flasklog, so we are likely to see a bunch for a while (especially on deleted/hidden talks where we haven't necessarily got everything that is now never null set to a non-null value), but this will help us clean things up.

Edgar, please review if you can, we should push to this to master and then to live soon.