### PR TITLE
Add chat link to series and talks

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -908,6 +908,7 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
     if not data["topics"]:
         errmsgs.append("Please select at least one topic.")
     data["language"] = languages.clean(data.get("language"))
+    print data["chat_link"]
 
     if data["online"]:
         if data["access_control"] == 2 and not data["access_hint"]:

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -908,7 +908,7 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
     if not data["topics"]:
         errmsgs.append("Please select at least one topic.")
     data["language"] = languages.clean(data.get("language"))
-    print data["chat_link"]
+    print("chat_link: " + data["chat_link"])
 
     if data["online"]:
         if data["access_control"] == 2 and not data["access_hint"]:

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -149,8 +149,8 @@
       <td class="forminfo" style="padding-top: 20px;">Leave blank if online only.</td>
     </tr>
     <tr>
-      <td style="width:150px; padding-top: 20px;">{{ KNOWL("chat_link") }}</td>
-      <td style="padding-top: 20px;"><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/myseries/#"></td>
+      <td>{{ KNOWL("chat_link") }}</td>
+      <td><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/#narrow/stream/seriesid"></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("online") }}</td>

--- a/seminars/create/templates/edit_seminar.html
+++ b/seminars/create/templates/edit_seminar.html
@@ -31,7 +31,7 @@
       </tr>
       <tr>
         <td>{{ ASTKNOWL("seminar_name") }}</td>
-        <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" maxlength="{{ maxlength['name'] }}" required /></td>
+        <td><input size="40" name="name" value="{{ seminar.name | blanknone }}" style="width:600px;" maxlength="{{ maxlength['name'] }}" /></td>
         <td class="forminfo">Capitalize only the first word and proper nouns.</td>
       </tr>
       <tr>
@@ -89,16 +89,16 @@
     <tr>
       <td style="padding-top: 20px">{{ ASTKNOWL("start_date") }}</td>
       <td style="padding-top: 20px">
-        <input name="start_date" style="width:600px;" value="{{ seminar.show_input_date(seminar.start_date) }}" style="width:600px;" placeholder="2020-01-27" required />
+        <input name="start_date" style="width:600px;" value="{{ seminar.show_input_date(seminar.start_date) }}" style="width:600px;" placeholder="2020-01-27" />
       </td>
     </tr>
     <tr>
       <td> {{ ASTKNOWL("end_date") }}</td>
-      <td><input name="end_date" value="{{ seminar.show_input_date(seminar.end_date) }}" style="width:600px;" placeholder="2020-01-31" required /></td>
+      <td><input name="end_date" value="{{ seminar.show_input_date(seminar.end_date) }}" style="width:600px;" placeholder="2020-01-31" /></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("per_day") }}</td>
-      <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" placeholder="1" required /></td>
+      <td><input name="per_day" value="{{ seminar.per_day | blanknone }}" style="width:600px;" placeholder="1" /></td>
     </tr>
   {% else %}
     <input id="num_slots" name="num_slots" style="display:none;" value="{{ seminar.time_slots|length }}">
@@ -147,6 +147,10 @@
       <td style="width:150px; padding-top: 20px;">{{ KNOWL("room") }}</td>
       <td style="padding-top: 20px;"><input name="room" value="{{ seminar.room | blanknone }}" style="width:600px;" maxlength="{{ maxlength['room'] }}" placeholder="Room 2-190 in the Simons building"></td>
       <td class="forminfo" style="padding-top: 20px;">Leave blank if online only.</td>
+    </tr>
+    <tr>
+      <td style="width:150px; padding-top: 20px;">{{ KNOWL("chat_link") }}</td>
+      <td style="padding-top: 20px;"><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/myseries/#"></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("online") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -81,8 +81,8 @@
       <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['video_link'] }}"placeholder="https://www.youtube.com/watch?v=abc123" /></td>
     </tr>
     <tr>
-      <td>{{ KNOWL("chat_link") }}</td>
-      <td><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/#narrow/stream/seriesid/"></td>
+      <td>{{ KNOWL("chat_link", "Chat link") }}</td>
+      <td><input name="chat_link" value="{{ talk.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/#narrow/stream/seriesid/"></td>
     </tr>
     <tr>
       <td>{{ KNOWL("abstract") }}</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -164,6 +164,10 @@
       <td class="forminfo">Leave blank if online only.</td>
     </tr>
     <tr>
+      <td style="width:150px; padding-top: 20px;">{{ KNOWL("chat_link") }}</td>
+      <td style="padding-top: 20px;"><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/myseries/#"></td>
+    </tr>
+    <tr>
       <td>{{ ASTKNOWL("online") }}</td>
       <td>
         <select id="online" name="online" style="width:610px;">

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -79,8 +79,12 @@
     <tr>
       <td>{{ KNOWL("video_link") }}</td>
       <td><input name="video_link" value="{{ talk.video_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['video_link'] }}"placeholder="https://www.youtube.com/watch?v=abc123" /></td>
-     </tr>
-     <tr>
+    </tr>
+    <tr>
+      <td>{{ KNOWL("chat_link") }}</td>
+      <td><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/#narrow/stream/seriesid/"></td>
+    </tr>
+    <tr>
       <td>{{ KNOWL("abstract") }}</td>
       <td style="align:right;"><a id="refresh-view" onclick="delay_refresh(); return false;" style="display: none;" href="#">(Refresh)</a></td>
     </tr>
@@ -162,10 +166,6 @@
       <td>{{ KNOWL("room") }}</td>
       <td><input name="room" value="{{ talk.room | blanknone }}" style="width:600px;" maxlength="{{ maxlength['room'] }}" placeholder="Room 2-190 in the Simons building" /></td>
       <td class="forminfo">Leave blank if online only.</td>
-    </tr>
-    <tr>
-      <td style="width:150px; padding-top: 20px;">{{ KNOWL("chat_link") }}</td>
-      <td style="padding-top: 20px;"><input name="chat_link" value="{{ seminar.chat_link | blanknone }}" style="width:600px;" maxlength="{{ maxlength['chat_link'] }}" placeholder="https/researchseminars.zulipchat.com/myseries/#"></td>
     </tr>
     <tr>
       <td>{{ ASTKNOWL("online") }}</td>

--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -252,6 +252,10 @@ room:
     Changing the room of a series has no impact on previously created talks.
     <br><br>
     Instructions to help visitors find the room should be entered in the Comments box (you can include a link to a campus map, for example).
+chat_link:
+  title: Chat stream
+  contents: |
+    The URL for a chat stream or other online discussion forum associated to the talk or series (this might link to a Zulip stream or topic, a Slack channel, or a Discord channel, for example).
 online:
   title: Online
   contents: |

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -88,6 +88,7 @@ required_seminar_columns = [
 optional_seminar_text_columns = [
     "access_hint",
     "access_registration",
+    "chat_link",
     "comments",
     "homepage",
     "live_link",

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -51,6 +51,7 @@ inherited_talk_columns = [
     "access_hint",
     "access_registration",
     "audience",
+    "chat_link",
     "display",
     "language",
     "live_link",
@@ -65,6 +66,7 @@ optional_talk_text_columns = [
     "abstract",
     "access_hint",
     "access_registration",
+    "chat_link",
     "comments",
     "live_link",
     "room",
@@ -520,8 +522,11 @@ Thank you,
     def show_video_link(self):
         return '<a href="%s">video</a>'%(self.video_link) if self.video_link else ""
 
+    def show_chat_link(self):
+        return '<a href="%s">chat</a>'%(self.chat_link) if self.chat_link else ""
+
     def show_content_links(self):
-        return '( ' + ' | '.join(filter(None,[self.show_paper_link(), self.show_slides_link(), self.show_video_link()])) + ' )'
+        return '( ' + ' | '.join(filter(None,[self.show_paper_link(), self.show_slides_link(), self.show_video_link(), self.show_chat_link()])) + ' )'
 
     @property
     def ics_link(self):

--- a/seminars/templates/talk-knowl.html
+++ b/seminars/templates/talk-knowl.html
@@ -22,8 +22,9 @@
       <p>{{ talk.show_lang_topics() | safe }}</p>
     {% endif %}
 
-    {% if talk.paper_link or talk.slides_link or talk.video_link %}
-      <p>{{ talk.show_content_links() | safe }}</p>
+    {% set content_links = talk.show_content_links() %}
+    {% if content_links %}
+    <p>{{ content_links | safe}}</p>
     {% endif %}
 
     {% if talk.comments and talk.comments != talk.seminar.comments %}

--- a/seminars/templates/talk.html
+++ b/seminars/templates/talk.html
@@ -51,8 +51,9 @@ If you are seeking an endorsement, ask someone on <a href="{{ url_for('user.publ
   {% endif %}
   <p>Audience: {{ talk.show_audience() | safe }}</p>
 
-  {% if talk.paper_link or talk.slides_link or talk.video_link %}
-  <p>{{talk.show_content_links() | safe}}</p>
+  {% set content_links = talk.show_content_links() %}
+  {% if content_links %}
+  <p>{{ content_links | safe}}</p>
   {% endif %}
 
   {% if talk.comments and talk.comments != talk.seminar.comments %}

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -47,6 +47,7 @@ maxlength = {
     'access_hint' : MAX_HINT_LEN,
     'access_registration' : MAX_URL_LEN,
     'aliases' : MAX_NAME_LEN,
+    'chat_link' : MAX_URL_LEN,
     'city' : MAX_NAME_LEN,
     'comments' : MAX_TEXT_LEN,
     'description' : MAX_DESCRIPTION_LEN,


### PR DESCRIPTION
For series the chat link is listed with the venue options, whereas for talks it is listed with the content options, which I think makes sense.  Content links now appear as ( paper | slides | video | chat ) with only non-empty links shown.