### PR TITLE
Hotfix for empty content link lists

### DIFF
--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -908,7 +908,6 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
     if not data["topics"]:
         errmsgs.append("Please select at least one topic.")
     data["language"] = languages.clean(data.get("language"))
-    print("chat_link: " + data["chat_link"])
 
     if data["online"]:
         if data["access_control"] == 2 and not data["access_hint"]:


### PR DESCRIPTION
Fixes a bug introduced when chat links were added causing empty content link lists to appear as ( ) rather than being completely omitted.