### PR TITLE
tweak audience option names

### DIFF
--- a/seminars/knowls.yaml
+++ b/seminars/knowls.yaml
@@ -508,9 +508,9 @@ audience:
     Select the <i>broadest</i> option that matches the intended audience 
     of the series or talk:
     <ul>
-      <li><b>researchers in topic</b>:
+      <li><b>researchers in the topic</b>:
           researchers in a particular topic within the discipline.</li>
-      <li><b>researchers in discipline</b>:
+      <li><b>researchers in the discipline</b>:
           researchers in the broader discipline 
           (e.g., all professors in a university department).</li>
       <li><b>advanced learners</b>:

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -63,8 +63,8 @@ visibility_options = [
 ]
 
 audience_options = [
-    (0, "researchers in topic"),
-    (1, "researchers in discipline"),
+    (0, "researchers in the topic"),
+    (1, "researchers in the discipline"),
     (2, "advanced learners"),
     (3, "learners"),
     (4, "undergraduates"),
@@ -301,7 +301,7 @@ class WebSeminar(object):
         return "conference" if self.is_conference else "seminar series"
 
     def show_audience(self):
-        return audience_options[self.audience][1]
+        return audience_options[self.audience][1].capitalize()
 
     def _show_date(self, d):
         format = "%a %b %-d" if d.year == datetime.now(self.tz).year else "%d-%b-%Y"


### PR DESCRIPTION
Since we have space everywhere it is used I changed "researchers in topic" to "researchers in the topic" and "researchers in discipline" to "researchers in the discipline".

I could see an argument for changing "topic" to "topic(s)" but did not do so.