### PR TITLE
Move description to comments

### DIFF
--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -454,6 +454,7 @@ class WebSeminar(object):
     def show_comments(self, prefix=""):
         if self.comments:
             comments = '\n'.join(self.comments.split("\n")[1:]).strip() if self.comments.startswith("Description:") else self.comments
+            print("comments: " + comments)
             return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + comments).split("\n\n"))
         else:
             return ""

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -453,7 +453,7 @@ class WebSeminar(object):
 
     def show_comments(self, prefix=""):
         if self.comments:
-            comments = self.comments.split("\n")[1:] if self.comments.startswith("Description:") else self.comments
+            comments = '\n'.join(self.comments.split("\n")[1:]) if self.comments.startswith("Description:") else self.comments
             return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + comments).split("\n\n"))
         else:
             return ""

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -454,7 +454,6 @@ class WebSeminar(object):
     def show_comments(self, prefix=""):
         if self.comments:
             comments = '\n'.join(self.comments.split("\n")[1:]).strip() if self.comments.startswith("Description:") else self.comments
-            print("comments: " + comments)
             return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + comments).split("\n\n"))
         else:
             return ""

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -246,7 +246,7 @@ class WebSeminar(object):
                 setattr(self, col, "")
         if hasattr(self, "description") and self.description:
             if not self.comments.startswith("Description:"):
-                self.comments = "Description: " + self.description + "\n" + self.comments
+                self.comments = "Description: " + self.description + "\n\n" + self.comments
             killattr(self, "description")
 
         if not  self.new:
@@ -453,7 +453,7 @@ class WebSeminar(object):
 
     def show_comments(self, prefix=""):
         if self.comments:
-            comments = '\n'.join(self.comments.split("\n")[1:]) if self.comments.startswith("Description:") else self.comments
+            comments = '\n'.join(self.comments.split("\n")[1:]).strip() if self.comments.startswith("Description:") else self.comments
             return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + comments).split("\n\n"))
         else:
             return ""

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -243,6 +243,11 @@ class WebSeminar(object):
         for col in optional_seminar_text_columns:
             if getattr(self, col) is None:
                 setattr(self, col, "")
+        if hasattr(self, "description") and self.description:
+            if not self.comments.startswith("Description:"):
+                self.comments = "Description: " + self.description + "\n" + self.comments
+            killattr(self.description)
+
         if not  self.new:
             self.validate()
 
@@ -386,8 +391,8 @@ class WebSeminar(object):
             return ""
 
     def show_description(self):
-        if self.description:
-            return self.description
+        if self.comments.startswith("Description:"):
+            return self.comments.split('\n')[0][12:].strip()
         else:
             return ""
 
@@ -447,6 +452,7 @@ class WebSeminar(object):
 
     def show_comments(self, prefix=""):
         if self.comments:
+            comments = self.comments.split("\n")[1:] if self.comments.startswith("Description:") else self.comments
             return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + self.comments).split("\n\n"))
         else:
             return ""

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -15,6 +15,7 @@ from seminars.utils import (
     weekdays,
     sanitized_table,
     log_error,
+    killattr,
 )
 from seminars.topic import topic_dag
 from seminars.toggle import toggle
@@ -453,7 +454,7 @@ class WebSeminar(object):
     def show_comments(self, prefix=""):
         if self.comments:
             comments = self.comments.split("\n")[1:] if self.comments.startswith("Description:") else self.comments
-            return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + self.comments).split("\n\n"))
+            return "\n".join("<p>%s</p>\n" % (elt) for elt in make_links(prefix + comments).split("\n\n"))
         else:
             return ""
 

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -247,7 +247,7 @@ class WebSeminar(object):
         if hasattr(self, "description") and self.description:
             if not self.comments.startswith("Description:"):
                 self.comments = "Description: " + self.description + "\n" + self.comments
-            killattr(self.description)
+            killattr(self, "description")
 
         if not  self.new:
             self.validate()

--- a/seminars/templates/seminar.html
+++ b/seminars/templates/seminar.html
@@ -29,10 +29,11 @@ If you are seeking an endorsement, see if you know anyone on this <a href="{{ ur
 {% endif %}
 
 <table style="border-collapse:separate; border-spacing: 0px 10px;">
-{% if seminar.description %}
+{% set description = seminar.show_description() %}
+{% if description %}
 <tr>
   <td style="padding:0px;">Description:</td>
-  <td>{{seminar.description | safe }}</td>
+  <td>{{ description | safe }}</td>
 </tr>
 {% endif %}
 <tr>


### PR DESCRIPTION
As discussed, this PR moves the description to the first line of the comments if it exists.  The "Description: " line on the View seminar page no longer uses the description column but will display the first line of the comments if it starts with "Description:"