### PR TITLE
Add reschedule option to edit talk page

### DIFF
--- a/seminars/api/main.py
+++ b/seminars/api/main.py
@@ -9,7 +9,6 @@ from seminars.users.pwdmanager import SeminarsUser, ilike_query
 from seminars.users.main import creator_required
 from seminars.utils import (
     allowed_shortname,
-    sanity_check_times,
     short_weekdays,
     process_user_input,
     sanitized_table,

--- a/seminars/api/main.py
+++ b/seminars/api/main.py
@@ -376,13 +376,11 @@ def save_series(version=0, user=None):
     warnings = []
     def warn(msg, *args):
         warnings.append(msg % args)
-    data, organizers, errmsgs = process_save_seminar(series, raw_data, warn, format_error, format_input_error, update_organizers, user=user)
-    if errmsgs:
+    new_version, errmsgs = process_save_seminar(series, raw_data, warn, format_error, format_input_error, update_organizers, user=user)
+    if new_version is None:
         raise APIError({"code": "processing_error",
                         "description": "Error in processing input",
                         "errors": errmsgs})
-    else:
-        new_version = WebSeminar(series_id, data=data, organizers=organizers, user=user)
     if series.new or new_version != series:
         # Series saved by the API are not displayed until user approves
         new_version.display = False
@@ -439,14 +437,11 @@ def save_talk(version=0, user=None):
     warnings = []
     def warn(msg, *args):
         warnings.append(msg % args)
-    data, errmsgs = process_save_talk(talk, raw_data, warn, format_error, format_input_error) # doesn't currently use the user
-    if errmsgs:
+    new_version, errmsgs = process_save_talk(talk, raw_data, warn, format_error, format_input_error) # doesn't currently use the user
+    if new_version is None:
         raise APIError({"code": "processing_error",
                         "description": "Error in processing input",
                         "errors": errmsgs})
-    else:
-        new_version = WebTalk(talk.seminar_id, data=data)
-    sanity_check_times(new_version.start_time, new_version.end_time)
     if talk.new or new_version != talk:
         # Talks saved by the API are not displayed until user approves
         new_version.display = False

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -453,7 +453,6 @@ def save_seminar():
     # Don't try to create new_version using invalid input
     if new_version is None:
         return show_input_errors(errmsgs)
-    else: # to make it obvious that these two statements should be together
 
     if seminar.new or new_version != seminar:
         new_version.save()

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -449,12 +449,11 @@ def save_seminar():
     if raw_data.get("submit") == "delete":
         return redirect(url_for(".delete_seminar", shortname=shortname), 302)
 
-    data, organizers, errmsgs = process_save_seminar(seminar, raw_data)
+    new_version, errmsgs = process_save_seminar(seminar, raw_data)
     # Don't try to create new_version using invalid input
-    if errmsgs:
+    if new_version is None:
         return show_input_errors(errmsgs)
     else: # to make it obvious that these two statements should be together
-        new_version = WebSeminar(shortname, data=data, organizers=organizers)
 
     if seminar.new or new_version != seminar:
         new_version.save()
@@ -641,7 +640,8 @@ def process_save_seminar(seminar, raw_data, warn=flash_warnmsg, format_error=for
                     "If none of the organizers has a confirmed account, add yourself and leave the organizer box unchecked.",
                 )
             )
-    return data, organizers, errmsgs
+    new_version = WebSeminar(shortname, data=data, organizers=organizers) if not errmsgs else None
+    return new_version, errmsgs
 
 @create.route("edit/institution/", methods=["GET", "POST"])
 @email_confirmed_required
@@ -839,17 +839,17 @@ def save_talk():
     if raw_data.get("submit") == "delete":
         return redirect(url_for(".delete_talk", seminar_id=talk.seminar_id, seminar_ctr=talk.seminar_ctr), 302)
 
-    data, errmsgs = process_save_talk(talk, raw_data)
+    new_version, errmsgs = process_save_talk(talk, raw_data)
     # Don't try to create new_version using invalid input
-    if errmsgs:
+    if new_version is None:
         return show_input_errors(errmsgs)
-    else: # to make it obvious that these two statements should be together
-        new_version = WebTalk(talk.seminar_id, data=data)
 
-    sanity_check_times(new_version.start_time, new_version.end_time)
     if new_version == talk:
         flash("No changes made to talk.")
     else:
+        if new_version.start_time != talk.start_time and raw_data.get("reschedule"):
+            talk.seminar_ctr = -talk.seminar_ctr
+            talk.save()
         new_version.save()
         if talk.new:
             flash("Talk successfully created!")
@@ -919,16 +919,17 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
                 errmsgs.append(format_errmsg("Registration link %s must be a valid URL or email address", data["access_registration"]))
 
     # Don't try to create new_version using invalid input
+    new_version = None
     if errmsgs:
         return data, errmsgs
     else:  # to make it obvious that these two statements should be together
         new_version = WebTalk(talk.seminar_id, data=data)
 
     # Warnings
-    sanity_check_times(new_version.start_time, new_version.end_time)
+    sanity_check_times(new_version.start_time, new_version.end_time, warn=warn)
     if "zoom" in data["video_link"] and not "rec" in data["video_link"]:
         warn("Recorded video link should not be used for Zoom meeting links; be sure to use Livestream link for meeting links.")
-    return data, errmsgs
+    return new_version, errmsgs
 
 def layout_schedule(seminar, data):
     """ Returns a list of schedule slots in specified date range (date, daytime-interval, talk)

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -918,11 +918,9 @@ def process_save_talk(talk, raw_data, warn=flash_warnmsg, format_error=format_er
                 errmsgs.append(format_errmsg("Registration link %s must be a valid URL or email address", data["access_registration"]))
 
     # Don't try to create new_version using invalid input
-    new_version = None
     if errmsgs:
-        return data, errmsgs
-    else:  # to make it obvious that these two statements should be together
-        new_version = WebTalk(talk.seminar_id, data=data)
+        return None, errmsgs
+    new_version = WebTalk(talk.seminar_id, data=data)
 
     # Warnings
     sanity_check_times(new_version.start_time, new_version.end_time, warn=warn)

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -126,9 +126,8 @@
       <td>{{ ASTKNOWL("talk_end_time") }}</td>
       <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" required /></td>
     </tr>
-    <tr class="reschedule">
-      <td></td><td>Talk will be displayed at the new time. Also display talk at the old time, crossed out. <input name="reschedule" value="yes" type="checkbox" /> </td>
-    </tr>
+    <tr class="reschedule"><td></td><td>Talk will be displayed at the new time.</td></tr>
+    <tr class="reschedule"><td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at the old time, crossed out.</td></tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}
     <input type="hidden" name="timezone" value="{{ talk.timezone }}" />

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -128,7 +128,7 @@
     </tr>
     <tr class="reschedule">
       <td> Talk will be displayed at the new time.</td>
-      <td> <input name="reschedule" value="yes" type="checkbox" /> Also display talk also the old time, crossed out. </td>
+      <td> <input name="reschedule" value="yes" type="checkbox" /> Also display talk at the old time, crossed out. </td>
     </tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -126,11 +126,9 @@
       <td>{{ ASTKNOWL("talk_end_time") }}</td>
       <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" required /></td>
     </tr>
-    <tr>
-      <td style="min-width:150px;">{{ KNOWL("reschedule_talk") }}</td>
-      <td>
-        <input name="hidden" value="yes" type="checkbox" />
-      </td>
+    <tr class="reschedule">
+      <td> Talk will be displayed at the new time.</td>
+      <td> <input name="reschedule" value="yes" type="checkbox" /> Also display talk also the old time, crossed out. </td>
     </tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -320,7 +320,7 @@
 
   function showreschedule() {
     $('tr.reschedule').hide()
-    if ( document.getElementById('start_time').value != "{{ talk.editable_start_time() }}" )
+    if ( $('select[name="start_time"]')[0].value != "{{ talk.editable_start_time() }}" )
       $('tr.reschedule').show();
     return false;
   }

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -320,7 +320,7 @@
 
   function showreschedule() {
     $('tr.reschedule').hide()
-    if ( $('select[name="start_time"]')[0].value != "{{ talk.editable_start_time() }}" )
+    if ( $('input[name="start_time"]')[0].value != "{{ talk.editable_start_time() }}" )
       $('tr.reschedule').show();
     return false;
   }

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -127,8 +127,7 @@
       <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" required /></td>
     </tr>
     <tr class="reschedule">
-      <td> Talk will be displayed at the new time.</td>
-      <td> <input name="reschedule" value="yes" type="checkbox" /> Also display talk at the old time, crossed out. </td>
+      <td></td><td>Talk will be displayed at the new time. Also display talk at the old time, crossed out. <input name="reschedule" value="yes" type="checkbox" /> </td>
     </tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -126,7 +126,12 @@
       <td>{{ ASTKNOWL("talk_end_time") }}</td>
       <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" required /></td>
     </tr>
-
+    <tr>
+      <td style="min-width:150px;">{{ KNOWL("reschedule_talk") }}</td>
+      <td>
+        <input name="hidden" value="yes" type="checkbox" />
+      </td>
+    </tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}
     <input type="hidden" name="timezone" value="{{ talk.timezone }}" />

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -320,7 +320,7 @@
 
   function showreschedule() {
     $('tr.reschedule').hide()
-    if ( document.getElementById('start_time').value != {{ talk.editable_start_time() }} )
+    if ( document.getElementById('start_time').value != "{{ talk.editable_start_time() }}" )
       $('tr.reschedule').show();
     return false;
   }

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -317,11 +317,21 @@
     }
     return false;
   }
+
+  function showreschedule() {
+    $('tr.reschedule').hide()
+    if ( document.getElementById('start_time').value != {{ talk.editable_start_time() }} )
+      $('tr.reschedule').show();
+    return false;
+  }
+
   $('select[name="online"]').change(showaccess);
   $('select[name="access_control"]').change(showaccess);
+  $('input[name="start_time"]')[0].addEventListener('keyup', (event) => { showreschedule(); });
 
   window.onpageshow = function(e) {
     showaccess();
+    showreschedule();
   };
 {% endif %}
 });

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -127,7 +127,7 @@
       <td><input name="end_time" value="{{ talk.editable_end_time() }}" style="width:600px;" required /></td>
     </tr>
     <tr class="reschedule"><td></td><td>Talk will be displayed at the new time.</td></tr>
-    <tr class="reschedule"><td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at the old time, crossed out.</td></tr>
+    <tr class="reschedule"><td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at the old time with title crossed out.</td></tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}
     <input type="hidden" name="timezone" value="{{ talk.timezone }}" />


### PR DESCRIPTION
I have not tested actually rescheduling a talk because I don't want to risk breaking the live site by creating a talk with a negative seminar_ctr.