### PR TITLE
Blackout reschedule option

### DIFF
--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -131,7 +131,7 @@
       <td></td><td>Talk will be displayed at the new time.</td>
     </tr>
     <tr class="reschedule">
-      {% if {{ talk.blackout_day() %}
+      {% if talk.blackout_day() %}
         <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out and black background.</td>
       {% else %}
         <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out.</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -131,7 +131,7 @@
       <td></td><td>Talk will be displayed at the new time.</td>
     </tr>
     <tr class="reschedule">
-      {% if talk.blackout_day() %}
+      {% if talk.blackout_date() %}
         <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out and black background.</td>
       {% else %}
         <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out.</td>

--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -131,7 +131,11 @@
       <td></td><td>Talk will be displayed at the new time.</td>
     </tr>
     <tr class="reschedule">
-      <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out.</td>
+      {% if {{ talk.blackout_day() %}
+        <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out and black background.</td>
+      {% else %}
+        <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }} with title crossed out.</td>
+      {% endif %}
     </tr>
     {% else %}
     {# non-organizers cannot edit the following attributes #}

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -20,11 +20,10 @@ from flask import abort, render_template, request, redirect, url_for, Response, 
 from seminars.seminar import seminars_search, all_seminars, all_organizers, seminars_lucky, next_talk_sorted, series_sorted, audience_options
 from flask_login import current_user
 import json
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 import pytz
 from collections import Counter
 from dateutil.parser import parse
-, WebTalk
 from lmfdb.utils import (
     flash_error,
     to_dict,

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -1,6 +1,6 @@
 from seminars.app import app
 from seminars import db
-from seminars.talk import talks_search, talks_lucky, talks_lookup
+from seminars.talk import talks_search, talks_lucky, talks_lookup, WebTalk
 from seminars.utils import (
     Toggle,
     ics_file,
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta, date
 import pytz
 from collections import Counter
 from dateutil.parser import parse
-
+, WebTalk
 from lmfdb.utils import (
     flash_error,
     to_dict,
@@ -36,7 +36,6 @@ from lmfdb.utils.search_boxes import (
     SearchButton,
     TextBox,
 )
-PROTEST_DATE = date(2020, 12, 10)
 
 from lmfdb.utils.search_parsing import collapse_ors
 
@@ -470,7 +469,7 @@ def _get_row_attributes(objects):
     visible_counter = 0
     for obj in objects:
         classes, filtered = filter_classes(obj)
-        if isinstance(obj, WebTalk) and adapt_datetime(obj.start_time, current_user.tz).date() == PROTEST_DATE and obj.rescheduled():
+        if isinstance(obj, WebTalk) and obj.blackout_date() and obj.rescheduled():
             classes.append("blm")
         style = ""
         if filtered:

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -470,8 +470,8 @@ def _get_row_attributes(objects):
     visible_counter = 0
     for obj in objects:
         classes, filtered = filter_classes(obj)
-        #if isinstance(obj, WebTalk) and adapt_datetime(obj.start_time, current_user.tz) == PROTEST_DATE and obj.rescheduled():
-        #    classes.append("blm")
+        if isinstance(obj, WebTalk) and adapt_datetime(obj.start_time, current_user.tz).date() == PROTEST_DATE and obj.rescheduled():
+            classes.append("blm")
         style = ""
         if filtered:
             style = ' style="display: none;"'

--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -1,6 +1,6 @@
 from seminars.app import app
 from seminars import db
-from seminars.talk import talks_search, talks_lucky, talks_lookup, WebTalk
+from seminars.talk import talks_search, talks_lucky, talks_lookup
 from seminars.utils import (
     Toggle,
     ics_file,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -307,8 +307,8 @@ class WebTalk(object):
         format = "%a %b %-d" if adapt_datetime(self.start_time, newtz=tz).year == datetime.now(tz).year else "%d-%b-%Y"
         return adapt_datetime(self.start_time, newtz=tz).strftime(format)
 
-    def blackout_date(self, tz=None):
-        return adapt_datetime(self.start_time, newtz=tz).strftime("%Y-%m-%d") in blackout_dates
+    def blackout_date(self):
+        return adapt_datetime(self.start_time, newtz=self.tz).strftime("%Y-%m-%d") in blackout_dates
 
     def show_time_and_duration(self, adapt=True, tz=None):
         start = self.start_time

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -34,7 +34,7 @@ import re
 
 blackout_dates = [ # Use %Y-%m-%d format
     "2020-06-10",
-    "2020-06-10",
+    "2021-06-10",
 ]
 
 required_talk_columns = [

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -32,9 +32,9 @@ from lmfdb.logger import critical
 from datetime import datetime, timedelta
 import re
 
-blackout_dates = [
-    "10 Jun 2020",
-    "10 Jun 2021",
+blackout_dates = [ # Use %Y-%m-%d format
+    "2020-06-10",
+    "2020-06-10",
 ]
 
 required_talk_columns = [
@@ -309,7 +309,7 @@ class WebTalk(object):
         return adapt_datetime(self.start_time, newtz=tz).strftime(format)
 
     def blackout_date(self, tz=None):
-        return adapt_datetime(self.start_time, newtz=tz).strftime("%d-%b-%Y") in blackout_dates
+        return adapt_datetime(self.start_time, newtz=tz).strftime("%Y-%m-%d") in blackout_dates
 
     def show_time_and_duration(self, adapt=True, tz=None):
         start = self.start_time

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -32,7 +32,7 @@ from lmfdb.logger import critical
 from datetime import datetime, timedelta
 import re
 
-blackout_days = [
+blackout_dates = [
     "10 Jun 2020",
     "10 Jun 2021",
 ]
@@ -309,7 +309,7 @@ class WebTalk(object):
         return adapt_datetime(self.start_time, newtz=tz).strftime(format)
 
     def blackout_date(self, tz=None):
-        return adapt_datetime(self.start_time, newtz=tz).strftime("%d-%b-%Y") in blackout_days
+        return adapt_datetime(self.start_time, newtz=tz).strftime("%d-%b-%Y") in blackout_dates
 
     def show_time_and_duration(self, adapt=True, tz=None):
         start = self.start_time

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -32,6 +32,11 @@ from lmfdb.logger import critical
 from datetime import datetime, timedelta
 import re
 
+blackout_days = [
+    "10 Jun 2020",
+    "10 Jun 2021",
+]
+
 required_talk_columns = [
     "audience",
     "by_api",
@@ -300,11 +305,11 @@ class WebTalk(object):
         return adapt_datetime(self.start_time, tz).strftime("%H:%M") + "-" + adapt_datetime(self.end_time, tz).strftime("%H:%M")
 
     def show_date(self, tz=None):
-        if self.start_time is None:
-            return ""
-        else:
-            format = "%a %b %-d" if adapt_datetime(self.start_time, newtz=tz).year == datetime.now(tz).year else "%d-%b-%Y"
-            return adapt_datetime(self.start_time, newtz=tz).strftime(format)
+        format = "%a %b %-d" if adapt_datetime(self.start_time, newtz=tz).year == datetime.now(tz).year else "%d-%b-%Y"
+        return adapt_datetime(self.start_time, newtz=tz).strftime(format)
+
+    def blackout_date(self, tz=None):
+        return adapt_datetime(self.start_time, newtz=tz).strftime("%d-%b-%Y") in blackout_days
 
     def show_time_and_duration(self, adapt=True, tz=None):
         start = self.start_time

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -34,7 +34,6 @@ import re
 
 blackout_dates = [ # Use %Y-%m-%d format
     "2020-06-10",
-    "2021-06-10",
 ]
 
 required_talk_columns = [

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -34,6 +34,7 @@ import re
 
 blackout_dates = [ # Use %Y-%m-%d format
     "2020-06-10",
+    "2020-12-10",
 ]
 
 required_talk_columns = [

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -733,6 +733,24 @@ table.ntdata > thead > tr.evenrow {
     background: {{color.table_ntdata_background_cn}} ! important;
 }
 
+table.ntdata > tr.even.blm,
+table.ntdata > tbody > tr.evenrow.blm,
+table.ntdata > tr.oddrow.blm,
+table.ntdata > tbody > tr.oddrow.blm {
+    background: #000000!important;
+    color: #f8d047!important;
+}
+table.ntdata tr.blm a {
+    color: #f8d047!important;
+}
+table.ntdata tr.blm a:hover {
+    background: #000000!important;
+}
+table.ntdata tr.blm *[knowl] {
+    border-bottom: 1px dotted #f8d047!important;
+}
+
+
 
 table.ntdata tr.toggle { font-size: 80%; text-align: left; }
 
@@ -805,20 +823,6 @@ table.ntdata td.institutions {
 }
 
 
-
-table.ntdata tr.blm {
-    background: #000000!important;
-    color: #f8d047!important;
-}
-table.ntdata tr.blm a {
-    color: #f8d047!important;
-}
-table.ntdata tr.blm a:hover {
-    background: #000000!important;
-}
-table.ntdata tr.blm *[knowl] {
-    border-bottom: 1px dotted #f8d047!important;
-}
 
 table.ntdata td.subscribe {
     text-align: right;


### PR DESCRIPTION
For talks rescheduled from one of the dates listed in blackout_dates in talk.py, if you edit the start time on the Edit talk page the text for the reschedule tick box will change to read

  Also display talk at {{ talk.editable_start_time() }} with title crossed out and black background.

I also changed the check against PROTEST_DATE in homepage/main.py to use the new blackout_date method (which checks the blackout_dates list).  Currently there are two blackout dates, June 10, 2020 and December 10, 2020, the later is for testing.

Note: unlike the check for PROTEST_DATE that David implemented, the blackout_date check uses the timezone of the talk not the timezone of the user (which I think is the right thing to do).