### PR TITLE
Tweak reschedule oneline

### DIFF
--- a/seminars/create/templates/edit_talk.html
+++ b/seminars/create/templates/edit_talk.html
@@ -132,9 +132,9 @@
     </tr>
     <tr class="reschedule">
       {% if talk.blackout_date() %}
-        <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }}, with title crossed out and black background.</td>
+        <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }}, crossed out with black background.</td>
       {% else %}
-        <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }}, with title crossed out.</td>
+        <td></td><td><input name="reschedule" value="yes" type="checkbox" />Also display talk at {{ talk.editable_start_time() }}, crossed out.</td>
       {% endif %}
     </tr>
     {% else %}

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -646,7 +646,7 @@ Thank you,
         rescheduled = self.rescheduled()
         t, now, e = adapt_datetime(self.start_time, newtz=tz), adapt_datetime(datetime.now(), newtz=tz), adapt_datetime(self.end_time, newtz=tz)
         if rescheduled:
-            datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate"><s>%b %d</s></td><td class="time"><s>%H:%M</s></td>')
+            datetime_tds = t.strftime('<td class="weekday"><i><s>%a</s></i></td><td class="monthdate"><i><s>%b %d</s></i></td><td class="time"><i><s>%H:%M</s></i></td>')
         else:
             if t < now < e:
                 datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time"><b>%H:%M</b></td>')

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -363,8 +363,8 @@ class WebTalk(object):
                 content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external, tz=tz)),
             )
         else:
-            if rescheduled:
-                return r'<a title="{title}" href="talk/{seminar_id}/{talkid}" style="text-decoration: line-through;">{title}</a> (rescheduled)'.format(
+            if rescheduled and self.blackout_date():
+                return r'<a title="{title}" href="talk/{seminar_id}/{talkid}"">{title}</a> (rescheduled)'.format(
                     title=self.show_title(),
                     seminar_id=self.seminar_id,
                     talkid=self.seminar_ctr,
@@ -657,7 +657,7 @@ Thank you,
             cols.append(("seriesname", self.show_seminar()))
         cols.append(("speaker", self.show_speaker(affiliation=False)))
         new_talk = talks_lookup(self.seminar_id, -self.seminar_ctr) if rescheduled else self
-        cols.append(("talktitle", new_talk.show_knowl_title(_external=_external, tz=tz)))
+        cols.append(("talktitle", new_talk.show_knowl_title(_external=_external, rescheduled=rescheduled, tz=tz)))
         if include_content:
             cols.append(('', self.show_slides_link()))
             cols.append(('', self.show_video_link()))

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -364,7 +364,7 @@ class WebTalk(object):
             )
         else:
             return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
-                title="<i><s>" + self.show_title() + "</s></i>&nbsp;(rescheduled)" if rescheduled else self.show_title(),
+                title=("<i><s>" + self.show_title() + "</s></i> (rescheduled)" if rescheduled) else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -363,13 +363,15 @@ class WebTalk(object):
                 content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external, tz=tz)),
             )
         else:
-            return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
+            s= r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
                 title=("<i><s>" + self.show_title() + "</s></i> (rescheduled)") if rescheduled else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,
                 reschedule=" (rescheduled)" if rescheduled else "",
             )
+            print(s)
+            return s
 
     def show_lang_topics(self):
         if self.language and self.language != "en":

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -363,22 +363,13 @@ class WebTalk(object):
                 content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external, tz=tz)),
             )
         else:
-            if rescheduled:
-                if 
-                return r'<a title="{title}" knowl="talk/{seminar_id}/{talkid}"">{title}</a> (rescheduled)'.format(
-                    title=self.show_title(),
-                    seminar_id=self.seminar_id,
-                    talkid=self.seminar_ctr,
-                )
-            else:
-                return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>{reschedule}'.format(
-                    title=self.show_title(),
-                    knowl_href="href" if blackout else "knowl",
-                    seminar_id=self.seminar_id,
-                    talkid=self.seminar_ctr,
-                    reschedule="(rescheduled)" if rescheduled else "",
-                )
-
+            return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>{reschedule}'.format(
+                title=self.show_title(),
+                knowl_href="href" if blackout else "knowl",
+                seminar_id=self.seminar_id,
+                talkid=self.seminar_ctr,
+                reschedule="(rescheduled)" if rescheduled else "",
+            )
 
     def show_lang_topics(self):
         if self.language and self.language != "en":

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -364,7 +364,7 @@ class WebTalk(object):
             )
         else:
             return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>{reschedule}'.format(
-                title="<i><s>" + self.show_title() + "</s></i>" if reschedule else self.show_title(),
+                title="<i><s>" + self.show_title() + "</s></i>" if rescheduled else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -363,15 +363,13 @@ class WebTalk(object):
                 content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external, tz=tz)),
             )
         else:
-            s= r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
+            return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
                 title=("<i><s>" + self.show_title() + "</s></i> (rescheduled)") if rescheduled else self.show_title(),
-                knowl_href="href" if blackout else "knowl",
+                knowl_href="href" if rescheduled else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,
                 reschedule=" (rescheduled)" if rescheduled else "",
             )
-            print(s)
-            return s
 
     def show_lang_topics(self):
         if self.language and self.language != "en":

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -363,8 +363,8 @@ class WebTalk(object):
                 content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external, tz=tz)),
             )
         else:
-            return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>{reschedule}'.format(
-                title="<i><s>" + self.show_title() + "</s></i>" if rescheduled else self.show_title(),
+            return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
+                title="<i><s>" + self.show_title() + "</s></i> (rescheduled)" if rescheduled else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -356,24 +356,27 @@ class WebTalk(object):
             title=self.show_title(),
         )
 
-    def show_knowl_title(self, _external=False, rescheduled=False, preload=False, tz=None):
+    def show_knowl_title(self, _external=False, rescheduled=False, blackout=False, preload=False, tz=None):
         if self.deleted or _external or preload:
             return r'<a title="{title}" knowl="dynamic_show" kwargs="{content}">{title}</a>'.format(
                 title=self.show_title(),
                 content=Markup.escape(render_template("talk-knowl.html", talk=self, _external=_external, tz=tz)),
             )
         else:
-            if rescheduled and self.blackout_date():
-                return r'<a title="{title}" href="talk/{seminar_id}/{talkid}"">{title}</a> (rescheduled)'.format(
+            if rescheduled:
+                if 
+                return r'<a title="{title}" knowl="talk/{seminar_id}/{talkid}"">{title}</a> (rescheduled)'.format(
                     title=self.show_title(),
                     seminar_id=self.seminar_id,
                     talkid=self.seminar_ctr,
                 )
             else:
-                return r'<a title="{title}" knowl="talk/{seminar_id}/{talkid}">{title}</a>'.format(
+                return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>{reschedule}'.format(
                     title=self.show_title(),
+                    knowl_href="href" if blackout else "knowl",
                     seminar_id=self.seminar_id,
                     talkid=self.seminar_ctr,
+                    reschedule="(rescheduled)" if rescheduled else "",
                 )
 
 
@@ -657,7 +660,7 @@ Thank you,
             cols.append(("seriesname", self.show_seminar()))
         cols.append(("speaker", self.show_speaker(affiliation=False)))
         new_talk = talks_lookup(self.seminar_id, -self.seminar_ctr) if rescheduled else self
-        cols.append(("talktitle", new_talk.show_knowl_title(_external=_external, rescheduled=rescheduled, tz=tz)))
+        cols.append(("talktitle", new_talk.show_knowl_title(_external=_external, rescheduled=rescheduled, blackout=self.blackout_date(), tz=tz)))
         if include_content:
             cols.append(('', self.show_slides_link()))
             cols.append(('', self.show_video_link()))

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -364,11 +364,11 @@ class WebTalk(object):
             )
         else:
             return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>{reschedule}'.format(
-                title=self.show_title(),
+                title="<i><s>" + self.show_title() + "</s></i>" if reschedule else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,
-                reschedule="(rescheduled)" if rescheduled else "",
+                reschedule=" (rescheduled)" if rescheduled else "",
             )
 
     def show_lang_topics(self):
@@ -647,11 +647,12 @@ Thank you,
             else:
                 datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time">%H:%M</td>')
         cols = []
+        rclass = " rescheduled" if rescheduled else ""
         if include_seminar:
-            cols.append(("seriesname", self.show_seminar()))
-        cols.append(("speaker", self.show_speaker(affiliation=False)))
+            cols.append(('class="seriesname%s"'%rclass, self.show_seminar()))
+        cols.append(('class="speaker%s"'%rclass, self.show_speaker(affiliation=False)))
         new_talk = talks_lookup(self.seminar_id, -self.seminar_ctr) if rescheduled else self
-        cols.append(("talktitle", new_talk.show_knowl_title(_external=_external, rescheduled=rescheduled, blackout=self.blackout_date(), tz=tz)))
+        cols.append(('class="talktitle"', new_talk.show_knowl_title(_external=_external, rescheduled=rescheduled, blackout=self.blackout_date(), tz=tz)))
         if include_content:
             cols.append(('', self.show_slides_link()))
             cols.append(('', self.show_video_link()))
@@ -661,8 +662,7 @@ Thank you,
                 cols.append(("", ""))
             else:
                 cols.append(('class="subscribe"', self.show_subscribe()))
-        tds = ''.join('<td class="%s rescheduled">%s</td>' % c for c in cols) if rescheduled else ''.join('<td class="%s">%s</td>' % c for c in cols)
-        return datetime_tds + tds
+        return datetime_tds + ''.join('<td class="%s">%s</td>' % c for c in cols)
 
     def show_comments(self, prefix=""):
         if self.comments:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -364,7 +364,7 @@ class WebTalk(object):
             )
         else:
             return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
-                title=("<i><s>" + self.show_title() + "</s></i> (rescheduled)" if rescheduled) else self.show_title(),
+                title=("<i><s>" + self.show_title() + "</s></i> (rescheduled)") if rescheduled else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -646,7 +646,7 @@ Thank you,
         rescheduled = self.rescheduled()
         t, now, e = adapt_datetime(self.start_time, newtz=tz), adapt_datetime(datetime.now(), newtz=tz), adapt_datetime(self.end_time, newtz=tz)
         if rescheduled:
-            datetime_tds = t.strftime('<td class="weekday"><i><s>%a</s></i></td><td class="monthdate"><i><s>%b %d</s></i></td><td class="time"><i><s>%H:%M</s></i></td>')
+            datetime_tds = t.strftime('<td class="weekday rescheduled">%a</i></td><td class="monthdate rescheduled">%b %d</td><td class="time rescheduled"><i>%H:%M</i></td>')
         else:
             if t < now < e:
                 datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time"><b>%H:%M</b></td>')
@@ -654,12 +654,9 @@ Thank you,
                 datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time">%H:%M</td>')
         cols = []
         if include_seminar:
-            cls = "seriesname rescheduled" if self.rescheduled() else "seriesname"
-            cols.append(('class="%s"'%cls, self.show_seminar()))
-        cls = "speaker rescheduled" if self.rescheduled() else "speaker"
-        cols.append(('class="%s"'%cls, self.show_speaker(affiliation=False)))
-        cls = "talktitle rescheduled" if self.rescheduled() else "talktitle"
-        cols.append(('class="talktitle"', self.show_knowl_title(_external=_external, rescheduled=rescheduled, tz=tz)))
+            cols.append(("seriesname", self.show_seminar()))
+        cols.append(("speaker", self.show_speaker(affiliation=False)))
+        cols.append(("talktitle", self.show_knowl_title(_external=_external, rescheduled=rescheduled, tz=tz)))
         if include_content:
             cols.append(('', self.show_slides_link()))
             cols.append(('', self.show_video_link()))
@@ -669,8 +666,8 @@ Thank you,
                 cols.append(("", ""))
             else:
                 cols.append(('class="subscribe"', self.show_subscribe()))
-        #cols.append(('style="display: none;"', self.show_link_title()))
-        return datetime_tds + "".join("<td %s>%s</td>" % c for c in cols)
+        tds = ''.join('<td class="%s rescheduled">%s</td>' % c for c in cols) if rescheduled else ''.join('<td class="%s">%s</td>' % c for c in cols)
+        return datetime_tds + tds
 
     def show_comments(self, prefix=""):
         if self.comments:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -364,7 +364,7 @@ class WebTalk(object):
             )
         else:
             return r'<a title="{title}" {knowl_href}="talk/{seminar_id}/{talkid}">{title}</a>'.format(
-                title="<i><s>" + self.show_title() + "</s></i> (rescheduled)" if rescheduled else self.show_title(),
+                title="<i><s>" + self.show_title() + "</s></i>&nbsp;(rescheduled)" if rescheduled else self.show_title(),
                 knowl_href="href" if blackout else "knowl",
                 seminar_id=self.seminar_id,
                 talkid=self.seminar_ctr,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -662,7 +662,7 @@ Thank you,
                 cols.append(("", ""))
             else:
                 cols.append(('class="subscribe"', self.show_subscribe()))
-        return datetime_tds + ''.join('<td class="%s">%s</td>' % c for c in cols)
+        return datetime_tds + ''.join('<td %s>%s</td>' % c for c in cols)
 
     def show_comments(self, prefix=""):
         if self.comments:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -656,7 +656,8 @@ Thank you,
         if include_seminar:
             cols.append(("seriesname", self.show_seminar()))
         cols.append(("speaker", self.show_speaker(affiliation=False)))
-        cols.append(("talktitle", self.show_knowl_title(_external=_external, rescheduled=rescheduled, tz=tz)))
+        new_talk = talks_lookup(self.seminar_id, -self.seminar_ctr) if rescheduled else self
+        cols.append(("talktitle", new_talk.show_knowl_title(_external=_external, tz=tz)))
         if include_content:
             cols.append(('', self.show_slides_link()))
             cols.append(('', self.show_video_link()))

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -369,7 +369,6 @@ class WebTalk(object):
                     seminar_id=self.seminar_id,
                     talkid=self.seminar_ctr,
                 )
-
             else:
                 return r'<a title="{title}" knowl="talk/{seminar_id}/{talkid}">{title}</a>'.format(
                     title=self.show_title(),
@@ -645,15 +644,10 @@ Thank you,
 
     def oneline(self, include_seminar=True, include_content=False, include_subscribe=True, tz=None, _external=False):
         rescheduled = self.rescheduled()
+        t, now, e = adapt_datetime(self.start_time, newtz=tz), adapt_datetime(datetime.now(), newtz=tz), adapt_datetime(self.end_time, newtz=tz)
         if rescheduled:
-            new_version = talks_lookup(self.seminar_id, -self.seminar_ctr)
-            self = new_version
-            t = adapt_datetime(self.start_time, newtz=tz)
-            datetime_tds = t.strftime('<td class="weekday rescheduled">Now</td><td class="monthdate">%b %d</td><td class="time">%H:%M</td>')
-
-
+            datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate"><s>%b %d</s></td><td class="time"><s>%H:%M</s></td>')
         else:
-            t, now, e = adapt_datetime(self.start_time, newtz=tz), adapt_datetime(datetime.now(), newtz=tz), adapt_datetime(self.end_time, newtz=tz)
             if t < now < e:
                 datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time"><b>%H:%M</b></td>')
             else:

--- a/seminars/templates/style.css
+++ b/seminars/templates/style.css
@@ -844,6 +844,7 @@ table.ntdata td.audience {
 
 table.ntdata td.rescheduled {
     font-style: italic;
+    text-decoration: line-through;
 }
 
 .talk-table td:nth-child(6) {


### PR DESCRIPTION
This PR changes rescheduled talk styling to show the old date/time and put a strikethru everything.

It keeps the talk page link on the title (rather than a knowl) because (a) the knowl looks horrible in blackout mode and (b) having a knowl title of the form "<i><s>title</s></i> (rescheduled)" does not work (clicking on the (rescheduled) part is fine but things break badly if you click on the title.  If we omitted the "(rescheduled)" it would work.