### PR TITLE
remove #ShutDownSTEM banner

### DIFF
--- a/seminars/templates/homepage.html
+++ b/seminars/templates/homepage.html
@@ -3,7 +3,7 @@
 {%- from "macros.html" import KNWOL, ASTKNOWL, calendar_block, prevent_unsaved with context -%}
 
 {% block body -%}
-<div class="banner">
+<!--<div class="banner">
   <header class="inner">
     <div style="padding: 8px 40px;">
       We at researchseminars.org, in solidarity with the
@@ -13,7 +13,7 @@
       scheduled that day to consider these movements.  We added an option on the Edit talk page for organizers to reschedule a talk.
     </div>
   </header>
-</div>
+</div>-->
 
 <div id="header">
   <header class="inner">


### PR DESCRIPTION
Comment out #ShutDownSTEM banner (I left all the formatting and styling in place in the commented out html so that if there is a similar event in the future we can easily recreate something similar).