### PR TITLE
Require name for new users and for instant registration, resolve #826

### DIFF
--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -852,7 +852,7 @@ def register_for_talk(seminar_id, talkid):
     # where the user will see an appropriate livestream link
     if talk.access_control != 4:
         return redirect(url_for('show_talk',seminar_id=seminar_id,talkid=talkid))
-    if current_user.is_anonymous:
+    if current_user.is_anonymous or len(current_user.name) < 2:
         return redirect(url_for("user.info", next=url_for("register_for_talk", seminar_id=seminar_id, talkid=talkid)))
     if not current_user.email_confirmed:
         flash_error("You need to confirm your email before you can register.")

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -430,7 +430,7 @@ class WebTalk(object):
         if raw:
             return link
         if self.is_starting_soon():
-            return '<div class="access_button is_link view_only"><b> <a href="%s">Watch view-only livestream <i class="play filter-white"></i></a></b></div>' % link
+            return '<div class="access_button is_link view_only"><b> <a href="%s">Watch livestream <i class="play filter-white"></i></a></b></div>' % link
         else:
             return '<div class="access_button is_link">View-only livestream access <a href="%s">available</a></div>' % link
 
@@ -447,7 +447,10 @@ class WebTalk(object):
             if raw:
                 return link if link else ''
             if not link:
-                return '<div class=access_button no_link">Interactive livestream not posted by organizers</div>'
+                if self.stream_link:
+                    return '<div class=access_button no_link">Interactive livestream link not posted by organizers</div>'
+                else:
+                    return '<div class=access_button no_link">Livestream link not posted by organizers</div>'
             if self.access_control == 4 and not self.user_is_registered(user):
                 link = url_for("register_for_talk", seminar_id=self.seminar_id, talkid=self.seminar_ctr, _external=external)
                 if self.is_starting_soon():

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -479,7 +479,7 @@ class WebTalk(object):
                                talkid=self.seminar_ctr,
                                _external=external
                                )
-            if user.is_anonymous:
+            if user.is_anonymous or (access_control == 4 and len(user.name) < 2):
                 link = url_for("user.info",
                                next=url_for("register_for_talk",
                                             seminar_id=self.seminar_id,
@@ -488,7 +488,7 @@ class WebTalk(object):
                 return '<div class="access_button no_link"><a href="%s">Login required</a> for livestream access</b></div>' % link
             elif not user.email_confirmed:
                 return '<div class="access_button no_link">Please confirm your email address for livestream access</div>'
-            elif not user.name:
+            elif access_control == 4 and not user.name:
                 return '<div class="access_button no_link"><a href="%s">Name required</a> for livestream access</b></div>' % link
             else:
                 return show_link(self, user=user, raw=raw)

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -478,7 +478,7 @@ class WebTalk(object):
                 return '<div class="access_button no_link"><a href="%s">Login required</a> for livestream access</b></div>' % link
             elif not user.email_confirmed:
                 return '<div class="access_button no_link">Please confirm your email address for livestream access</div>'
-            elif access_control == 4 and not len(user.name) < 2:
+            elif self.access_control == 4 and not len(user.name) < 2:
                 return '<div class="access_button no_link"><a href="%s">Name required</a> for livestream access</b></div>' % link
             else:
                 return show_link(self, user=user, raw=raw)

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -488,6 +488,8 @@ class WebTalk(object):
                 return '<div class="access_button no_link"><a href="%s">Login required</a> for livestream access</b></div>' % link
             elif not user.email_confirmed:
                 return '<div class="access_button no_link">Please confirm your email address for livestream access</div>'
+            elif not user.name:
+                return '<div class="access_button no_link"><a href="%s">Name required</a> for livestream access</b></div>' % link
             else:
                 return show_link(self, user=user, raw=raw)
         elif self.access_control == 5:

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -449,10 +449,7 @@ class WebTalk(object):
             if not link:
                 return '<div class=access_button no_link">Livestream link not yet posted by organizers</div>'
             if self.access_control == 4 and not self.user_is_registered(user):
-                link = url_for("register_for_talk",
-                               seminar_id=self.seminar_id,
-                               talkid=self.seminar_ctr,
-                               _external=external)
+                link = url_for("register_for_talk", seminar_id=self.seminar_id, talkid=self.seminar_ctr, _external=external)
                 if self.is_starting_soon():
                     return '<div class="access_button is_link starting_soon"><b> <a href="%s">Instantly register and join livestream <i class="play filter-white"></i> </a></b></div>' % link
                 else:
@@ -474,21 +471,14 @@ class WebTalk(object):
             return show_link(self, user=user, raw=raw)
         elif self.access_control in [3,4]:
             if raw:
-                return url_for("show_talk",
-                               seminar_id=self.seminar_id,
-                               talkid=self.seminar_ctr,
-                               _external=external
-                               )
+                return url_for("show_talk", seminar_id=self.seminar_id, talkid=self.seminar_ctr, _external=external)
             if user.is_anonymous or (self.access_control == 4 and len(user.name) < 2):
-                link = url_for("user.info",
-                               next=url_for("register_for_talk",
-                                            seminar_id=self.seminar_id,
-                                            talkid=self.seminar_ctr),
-                               _external=external)
+                link = url_for("user.info", next=url_for("register_for_talk", seminar_id=self.seminar_id, talkid=self.seminar_ctr), _external=external)
+            if user.is_anonymous:
                 return '<div class="access_button no_link"><a href="%s">Login required</a> for livestream access</b></div>' % link
             elif not user.email_confirmed:
                 return '<div class="access_button no_link">Please confirm your email address for livestream access</div>'
-            elif access_control == 4 and not user.name:
+            elif access_control == 4 and not len(user.name) < 2:
                 return '<div class="access_button no_link"><a href="%s">Name required</a> for livestream access</b></div>' % link
             else:
                 return show_link(self, user=user, raw=raw)
@@ -500,10 +490,7 @@ class WebTalk(object):
                     return show_link(self, user=user, raw=raw)
             # If there is a view-only link, show that rather than an external registration link
             if raw:
-                return url_for("show_talk",
-                               seminar_id=self.seminar_id,
-                               talkid=self.seminar_ctr,
-                               _external=external)
+                return url_for("show_talk", seminar_id=self.seminar_id, talkid=self.seminar_ctr, _external=external)
             if not self.access_registration:
                 # This should never happen, registration link is required, but just in case...
                 return "" if raw else '<div class="access_button no_link">Registration required, see comments or external site.</a></div>' % link
@@ -527,10 +514,7 @@ Thank you,
                     talk = self.title,
                     speaker = self.show_speaker(raw=True),
                     series = self.seminar.name,
-                    url = url_for('show_talk',
-                                  seminar_id=self.seminar.shortname,
-                                  talkid=self.seminar_ctr,
-                                  _external=True),
+                    url = url_for('show_talk', seminar_id=self.seminar.shortname, talkid=self.seminar_ctr, _external=True),
                     user = user.name)
                 msg = { "body": body, "subject": "Request to attend %s" % self.seminar.shortname }
                 link = "mailto:%s?%s" % (self.access_registration, urlencode(msg, quote_via=quote))

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -479,7 +479,7 @@ class WebTalk(object):
                                talkid=self.seminar_ctr,
                                _external=external
                                )
-            if user.is_anonymous or (access_control == 4 and len(user.name) < 2):
+            if user.is_anonymous or (self.access_control == 4 and len(user.name) < 2):
                 link = url_for("user.info",
                                next=url_for("register_for_talk",
                                             seminar_id=self.seminar_id,

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -478,7 +478,7 @@ class WebTalk(object):
                 return '<div class="access_button no_link"><a href="%s">Login required</a> for livestream access</b></div>' % link
             elif not user.email_confirmed:
                 return '<div class="access_button no_link">Please confirm your email address for livestream access</div>'
-            elif self.access_control == 4 and not len(user.name) < 2:
+            elif self.access_control == 4 and len(user.name) < 2:
                 return '<div class="access_button no_link"><a href="%s">Name required</a> for livestream access</b></div>' % link
             else:
                 return show_link(self, user=user, raw=raw)

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -430,7 +430,7 @@ class WebTalk(object):
         if raw:
             return link
         if self.is_starting_soon():
-            return '<div class="access_button is_link view_only"><b> <a href="%s">Watch livestream <i class="play filter-white"></i></a></b></div>' % link
+            return '<div class="access_button is_link view_only"><b> <a href="%s">Watch view-only livestream <i class="play filter-white"></i></a></b></div>' % link
         else:
             return '<div class="access_button is_link">View-only livestream access <a href="%s">available</a></div>' % link
 
@@ -447,7 +447,7 @@ class WebTalk(object):
             if raw:
                 return link if link else ''
             if not link:
-                return '<div class=access_button no_link">Livestream link not yet posted by organizers</div>'
+                return '<div class=access_button no_link">Interactive livestream not posted by organizers</div>'
             if self.access_control == 4 and not self.user_is_registered(user):
                 link = url_for("register_for_talk", seminar_id=self.seminar_id, talkid=self.seminar_ctr, _external=external)
                 if self.is_starting_soon():

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -207,8 +207,8 @@ def set_info():
             data[col] = process_user_input(val, col, typ)
         except Exception as err:  # should only be ValueError's but let's be cautious
             errmsgs.append(format_input_errmsg(err, val, col))
-    if not data.get("name"):
-        errmsgs.append(format_errmsg('Name cannot be left blank.  See the user behavior section of our <a href="' + url_for('policies') + '" target="_blank">policies</a> page for details.'))
+    if len(data.get("name","")) < 2:
+        errmsgs.append(format_errmsg('Name too short.  See the user behavior section of our <a href="' + url_for('policies') + '" target="_blank">policies</a> page for details.'))
     if errmsgs:
         return show_input_errors(errmsgs)
     data["external_ids"] = external_ids

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -249,9 +249,13 @@ def housekeeping(fn):
 @login_page.route("/register/", methods=["GET", "POST"])
 def register():
     if request.method == "POST":
+        name = request.form["name"].strip()
         email = request.form["email"]
         pw1 = request.form["password1"]
         pw2 = request.form["password2"]
+        if len(name) < 2:
+            flash_error("Oops, name is too short.  Please enter at least 2 characters.")
+            return make_response(render_template("register.html", title="Register", email=email))            
         try:
             email = validate_email(email)['email']
         except EmailNotValidError as e:

--- a/seminars/users/main.py
+++ b/seminars/users/main.py
@@ -189,7 +189,7 @@ def set_info():
     previous_email = current_user.email
     external_ids = []
     for col, val in request.form.items():
-        if col == "ids":
+        if col == "ids" or col == "next":
             continue
         try:
             # handle external id values separately, these are not named columns, they all go in external_ids
@@ -219,8 +219,7 @@ def set_info():
     if previous_email != current_user.email:
         if send_confirmation_email(current_user.email):
             flask.flash(Markup("New confirmation email has been sent!"))
-    return redirect(url_for(".info"))
-
+    return redirect(request.form.get("next") or url_for(".info"))
 
 @login_page.route("/send_confirmation_email")
 @login_required

--- a/seminars/users/templates/register.html
+++ b/seminars/users/templates/register.html
@@ -20,6 +20,11 @@ the <a href="{{ url_for('privacy') }}" target="_blank">privacy policy</a>.
 <form name="login" action="{{ url_for('.register') }}" method="POST">
   <table>
     <tr>
+      <td>Name:</td>
+      <td><input name="name" size="30" value="{{ name }}" required /></td>
+      <td colspan="2" class="forminfo"></td></tr>
+    <tr>
+    <tr>
       <td>Email:</td>
       <td><input name="email" size="30" value="{{ email }}" required /></td>
       <td colspan="2" class="forminfo">By default, not visible to others.</td></tr>

--- a/seminars/users/templates/user-info.html
+++ b/seminars/users/templates/user-info.html
@@ -101,6 +101,7 @@
   <h2>Edit my details</h2>
 
   <form action="{{ url_for('.set_info') }}" method="post" name="userinfo">
+    <input type="hidden" name="next" value="{{ next }}" />
     <table>
       <tr>
         <td width="160">Created</td>


### PR DESCRIPTION
With this PR a name of at least 2 characters in length is now required when accounts are created, and in order to instantly register for livestream access.  It does not impact users with blank names that have already instantly registered.

Users who are not logged in currently see "Login required for livestream access" where "Login required" is a link to the login page that will then redirect to the talk reigstration page.

With the PR, logged in users with blank names (or names of length 1) will see "Name required for livestream access" where "Name required" is a link to the user info page that will redirect to the talk registration page after they update their name (they should not be able to submit the form and redirect without setting their name, but even if they do the register_talk route checks for the name and will redirect them back to the user info page if it is not set (and at least 2 characters long).

This PR also fixes #826 by distinguishing the interactive livestream -- it will say "Interactive livestream link not posted by organizers" next to "Watch livestream" in a situation where stream_link is set but live_link is not (if neither are available it will just say "Livestream link not posted by organizers".