### PR TITLE
Select right element for knowl when math clicked

### DIFF
--- a/seminars/static/knowl.js
+++ b/seminars/static/knowl.js
@@ -128,7 +128,7 @@ function toggle(element) {
 }
 
 function knowl_click_handler(evt) {
-  var knowl = evt.target || evt.srcElement
+  var knowl = evt.currentTarget || evt.srcElement
   var uid = knowl.getAttribute("knowl-uid")
   var output_id = 'knowl-output-' + uid
   var output = document.getElementById(output_id)
@@ -279,7 +279,7 @@ function knowl_click_handler(evt) {
 var knowl_id_counter = 0
 function knowl_handle(evt) {
   evt.preventDefault()
-  var knowl = evt.target || evt.srcElement
+  var knowl = evt.currentTarget || evt.srcElement
   if(!knowl.getAttribute("knowl-uid") ) {
     knowl.setAttribute("knowl-uid", knowl_id_counter)
     knowl_id_counter++


### PR DESCRIPTION
Currently on chrome when I click on katex-ified math in a title on the frontpage to reveal the knowl the knowl output breaks.
This only happens when I click on the math itself, as the knowl render code selects the span used to render the math and tries to use that to find the knowl and place the output, this short patch looks to fix the issue for me (see https://developer.mozilla.org/en-US/docs/Web/API/Event/target).

before:
<img width="1207" alt="Screen Shot 2020-10-20 at 16 01 06" src="https://user-images.githubusercontent.com/1688533/96638020-856d1600-12ed-11eb-95c1-8f05d2f77d3e.png">

after:
<img width="1050" alt="Screen Shot 2020-10-20 at 16 02 39" src="https://user-images.githubusercontent.com/1688533/96638148-b51c1e00-12ed-11eb-9a33-0667c5d2e903.png">

Its unclear to me if a similar change is needed for lmfdb itself?