### PR TITLE
display timezones as tooltips in embedded schedules

### DIFF
--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -642,12 +642,12 @@ Thank you,
         rescheduled = self.rescheduled()
         t, now, e = adapt_datetime(self.start_time, newtz=tz), adapt_datetime(datetime.now(), newtz=tz), adapt_datetime(self.end_time, newtz=tz)
         if rescheduled:
-            datetime_tds = t.strftime('<td class="weekday rescheduled">%a</td><td class="monthdate rescheduled">%b %d</td><td class="time rescheduled">%H:%M</td>')
+            datetime_tds = t.strftime('<td class="weekday rescheduled">%a</td><td class="monthdate rescheduled">%b %d</td><td class="time rescheduled" title="%Z">%H:%M</td>')
         else:
             if t < now < e:
-                datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time"><b>%H:%M</b></td>')
+                datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time" title="%Z"><b>%H:%M</b></td>')
             else:
-                datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time">%H:%M</td>')
+                datetime_tds = t.strftime('<td class="weekday">%a</td><td class="monthdate">%b %d</td><td class="time" title="%Z">%H:%M</td>')
         cols = []
         rclass = " rescheduled" if rescheduled else ""
         if include_seminar:


### PR DESCRIPTION
This may not be the proper way to implement this -- feel free to reject this PR and consider this a feature request :smile: I don't have access to the development DB so it's not tested.

I noticed at https://leanprover-community.github.io/lt2024/schedule.html that the embedded schedule doesn't give any indication of the timezone. I've added text about this on the webpage, but it would be nice if hovering over a time gave a tooltip with the time zone. This is what I've tried to implement here, in the most basic way possible.