### PR TITLE
master -> live

### DIFF
--- a/seminars/homepage/main.py
+++ b/seminars/homepage/main.py
@@ -392,6 +392,9 @@ def index():
     if request.args.get("submit"):
         x = request.args["submit"].strip().split(' ')
         subsection=x[0]
+        # these are the only routes to redirect for
+        if subsection not in ['talks', 'past_talks', 'seminar_series', 'conferences', 'past_conferences']:
+            return abort(404, "Page not found")
         keywords = ' '.join(x[1:])
         return redirect(url_for_with_args(subsection+"_index", {'keywords': keywords} if keywords else {}))
     return _talks_index(subsection="talks",

--- a/seminars/templates/seminar-embed-code-knowl.html
+++ b/seminars/templates/seminar-embed-code-knowl.html
@@ -23,7 +23,7 @@
 <p>
   Due to a <a href="https://katex.org/docs/issues">katex issue</a>, if you want latex to work in your embedded schedule you must also ensure that the first line in your html file is
 </p>
-<textarea style="width: calc(100% - 20px);" rows=1 readonly id="embed-doctype" onclick="this.focus();this.select()"><!DOCTYPE html></textarea>
+<textarea style="width: calc(100% - 20px); height: 1.1em" rows=1 readonly id="embed-doctype" onclick="this.focus();this.select()"><!DOCTYPE html></textarea>
 <div style="margin-bottom:10px;"><a onclick="copySourceOfId('embed-doctype')"><i class="clippy"></i> Copy code to clipboard</a></div>
 
 <script async>add_autoselect_event();</script>


### PR DESCRIPTION
@roed314 I would appreciate a second set of eyes on this one

The issue is:
```
2024-04-09 07:06:43,782 ERROR in app [/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py:1741]:
  Exception on / [GET]
Traceback (most recent call last):
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/home/mathseminars/seminars-git-live/seminars/homepage/main.py", line 396, in index
    return redirect(url_for_with_args(subsection+"_index", {'keywords': keywords} if keywords else {}))
  File "/home/mathseminars/seminars-git-live/seminars/utils.py", line 783, in url_for_with_args
    return url_for(name, **kwargs) + query
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/helpers.py", line 256, in url_for
    return current_app.url_for(
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 2031, in url_for
    return self.handle_url_build_error(error, endpoint, values)
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/flask/app.py", line 2020, in url_for
    rv = url_adapter.build(  # type: ignore[union-attr]
  File "/home/sage/sage-9.7/local/var/lib/sage/venv-python3.10.5/lib/python3.10/site-packages/werkzeug/routing/map.py", line 917, in build
    raise BuildError(endpoint, values, method, self)
werkzeug.routing.exceptions.BuildError: Could not build url for endpoint 'past_index'. Did you mean 'past_talks_index' instead?
2024-04-09 07:06:43,794 ERROR in app [/home/mathseminars/seminars-git-live/seminars/app.py:252]:
  [2024-04-09 11:06:43 UTC] 500 error on URL https://researchseminars.org/?submit=past ()