### PR TITLE
Stop depending on psycodict's extras-table APIs

### DIFF
--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -10,7 +10,9 @@ from seminars.utils import (
     lucky_distinct,
     make_links,
     max_distinct,
+    plain_iterator,
     search_distinct,
+    search_iterator,
     show_input_errors,
     weekdays,
     sanitized_table,
@@ -709,12 +711,12 @@ def _construct(organizer_dict, institution_dict, objects=True, more=False):
 
 
 def _iterator(organizer_dict, institution_dict, objects=True, more=False):
-    def object_iterator(cur, search_cols, extra_cols, projection):
-        for rec in db.seminars._search_iterator(cur, search_cols, extra_cols, projection):
+    def object_iterator(cur, cols, projection):
+        for rec in search_iterator(db.seminars, cur, cols, projection):
             if isinstance(rec, dict) and "shortname" in rec and not rec["shortname"] in organizer_dict:
                 continue
             yield _construct(organizer_dict, institution_dict, more=more)(rec)
-    return object_iterator if objects else db.seminars._search_iterator
+    return object_iterator if objects else plain_iterator(db.seminars)
 
 
 def seminars_count(query={}, include_deleted=False):
@@ -828,7 +830,7 @@ SELECT DISTINCT ON (seminar_id) {0} FROM
             db.talks,
             _selecter,
             talks_counter,
-            db.talks._search_iterator,
+            plain_iterator(db.talks),
             query,
             projection=["seminar_id", "start_time"],
             sort=["seminar_id", "start_time"]):

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -15,8 +15,10 @@ from seminars.utils import (
     lucky_distinct,
     make_links,
     max_distinct,
+    plain_iterator,
     sanitized_table,
     search_distinct,
+    search_iterator,
 )
 from seminars.language import languages
 from seminars.toggle import toggle
@@ -865,11 +867,11 @@ def _construct(seminar_dict, objects=True, more=False):
 
 
 def _iterator(seminar_dict, objects=True, more=False):
-    def object_iterator(cur, search_cols, extra_cols, projection):
-        for rec in db.talks._search_iterator(cur, search_cols, extra_cols, projection):
+    def object_iterator(cur, cols, projection):
+        for rec in search_iterator(db.talks, cur, cols, projection):
             yield _construct(seminar_dict, more=more)(rec)
 
-    return object_iterator if objects else db.talks._search_iterator
+    return object_iterator if objects else plain_iterator(db.talks)
 
 
 def talks_count(query={}, include_deleted=False):

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -22,6 +22,43 @@ from psycodict.searchtable import PostgresSearchTable
 from .toggle import toggle
 
 
+# psycodict used to allow a table to be split into a search table and an
+# "extras" table, and several of the private methods used below took the extras
+# columns as a separate argument.  The helpers here work with psycodict either
+# side of that removal; once the psycodict requirement is pinned past it, this
+# flag and the branches guarded by it can go.
+_psycodict_has_extras = hasattr(PostgresSearchTable, "_get_table_clause")
+
+
+def parse_projection(table, projection):
+    """
+    The columns a projection selects, as a flat tuple of names.
+    """
+    cols = table._parse_projection(projection)
+    if _psycodict_has_extras:
+        cols = cols[0] + cols[1]
+    return cols
+
+
+def search_iterator(table, cur, cols, projection):
+    """
+    Iterate over the results in a cursor, yielding dictionaries keyed by ``cols``.
+    """
+    if _psycodict_has_extras:
+        return table._search_iterator(cur, cols, (), projection)
+    return table._search_iterator(cur, cols, projection)
+
+
+def plain_iterator(table):
+    """
+    An iterator for ``search_distinct`` that yields dictionaries rather than
+    Web* objects.
+    """
+    def iterator(cur, cols, projection):
+        return search_iterator(table, cur, cols, projection)
+    return iterator
+
+
 weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 short_weekdays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 daytime_re_string = r"\d{1,4}|\d{1,2}:\d\d|"
@@ -390,14 +427,15 @@ def search_distinct(
     """
     Replacement for db.*.search to account for versioning, return Web* objects.
 
-    Doesn't support split_ors, raw or extra tables.  Always computes count.
+    Doesn't support split_ors or raw.  Always computes count.
 
     INPUT:
 
     - ``table`` -- a search table, such as db.seminars or db.talks
     - ``counter`` -- an SQL object counting distinct entries
     - ``selecter`` -- an SQL objecting selecting distinct entries
-    - ``iterator`` -- an iterator taking the same arguments as ``_search_iterator``
+    - ``iterator`` -- a callable ``(cur, cols, projection)`` yielding one object
+      per row, such as the result of ``plain_iterator``
     """
     if offset < 0:
         raise ValueError("Offset cannot be negative")
@@ -405,7 +443,7 @@ def search_distinct(
     if not include_deleted:
         query["deleted"] = {"$or": [False, {"$exists": False}]}
     all_cols = SQL(", ").join(map(IdentifierWrapper, ["id"] + table.search_cols))
-    search_cols, extra_cols = table._parse_projection(projection)
+    cols = parse_projection(table, projection)
     tbl = IdentifierWrapper(table.search_table)
     if limit is None:
         qstr, values = table._build_query(query, sort=sort)
@@ -426,12 +464,12 @@ def search_distinct(
             more = Placeholder()
             moreval = [True]
 
-        cols = SQL(", ").join(list(map(IdentifierWrapper, search_cols + extra_cols)) + [more])
-        extra_cols = extra_cols + ("more",)
+        fcols = SQL(", ").join(list(map(IdentifierWrapper, cols)) + [more])
+        cols = cols + ("more",)
         values = moreval + values
     else:
-        cols = SQL(", ").join(map(IdentifierWrapper, search_cols + extra_cols))
-    fselecter = selecter.format(cols, all_cols, tbl, qstr)
+        fcols = SQL(", ").join(map(IdentifierWrapper, cols))
+    fselecter = selecter.format(fcols, all_cols, tbl, qstr)
     cur = table._execute(
         fselecter,
         values,
@@ -445,7 +483,7 @@ def search_distinct(
             offset,
         ),
     )
-    results = iterator(cur, search_cols, extra_cols, projection)
+    results = iterator(cur, cols, projection)
     if info is not None:
         # caller is requesting count data
         nres = count_distinct(table, counter, query)
@@ -495,10 +533,10 @@ def lucky_distinct(
     if not include_deleted:
         query["deleted"] = {"$or": [False, {"$exists": False}]}
     all_cols = SQL(", ").join(map(IdentifierWrapper, ["id"] + table.search_cols))
-    search_cols, extra_cols = table._parse_projection(projection)
-    cols = SQL(", ").join(map(IdentifierWrapper, search_cols + extra_cols))
+    cols = parse_projection(table, projection)
+    fcols = SQL(", ").join(map(IdentifierWrapper, cols))
     qstr, values = table._build_query(query, 1, offset, sort=sort)
-    tbl = table._get_table_clause(extra_cols)
+    tbl = IdentifierWrapper(table.search_table)
     prequery = {} if include_pending else {'$or': [{'display': True}, {'by_api': False}]}
     if prequery:
         # We filter the records before finding the most recent (normal queries filter after finding the most recent)
@@ -508,14 +546,14 @@ def lucky_distinct(
         if pqstr is not None:
             tbl = tbl + SQL(" WHERE {0}").format(pqstr)
             values = pqvalues + values
-    fselecter = selecter.format(cols, all_cols, tbl, qstr)
+    fselecter = selecter.format(fcols, all_cols, tbl, qstr)
     cur = table._execute(fselecter, values)
     if cur.rowcount > 0:
         rec = cur.fetchone()
         if projection == 0 or isinstance(projection, string_types):
             rec = rec[0]
         else:
-            rec = {k: v for k, v in zip(search_cols + extra_cols, rec)}
+            rec = {k: v for k, v in zip(cols, rec)}
         return construct(rec)
 
 
@@ -853,7 +891,8 @@ class APIError(Exception):
 def sanitized_table(name):
     cur = db._execute(SQL(
         "SELECT name, label_col, sort, count_cutoff, id_ordered, out_of_order, "
-        "has_extras, stats_valid, total, include_nones FROM meta_tables WHERE name=%s"
+        + ("has_extras, " if _psycodict_has_extras else "")
+        + "stats_valid, total, include_nones FROM meta_tables WHERE name=%s"
     ), [name])
     def update(self, query, changes, resort=False, restat=False):
         raise APIError({"code": "update_prohibited"})


### PR DESCRIPTION
psycodict is removing the search/extras table split before its 1.0 release ([roed314/psycodict#59](https://github.com/roed314/psycodict/pull/59)). That changes three private APIs this code calls:

| API | before | after |
|---|---|---|
| `_parse_projection` | returns `(search_cols, extra_cols)` | returns a single tuple of columns |
| `_search_iterator` | `(cur, search_cols, extra_cols, projection)` | `(cur, search_cols, projection)` |
| `_get_table_clause` | adds the join to the extras table | removed |

These sit under `search_distinct` and `lucky_distinct`, i.e. the main seminar and talk listings, so getting the timing wrong would be a visible outage.

## Deployable in either order

**The new helpers work against psycodict on both sides of the change, so this can merge and deploy before or after psycodict updates.** All version-dependence is behind a single probe, `_psycodict_has_extras`; once `requirements.txt` pins psycodict past the removal, that probe and its branches can be deleted and the helpers inlined. (Right now `requirements.txt` tracks psycodict by unpinned git URL, so a fresh install picks up whatever is on master — which is exactly why this is worth making tolerant rather than atomic.)

## Changes

Three helpers in `utils.py` — `parse_projection`, `search_iterator`, `plain_iterator` — are now the only code touching those private APIs.

- **`search_distinct`** and **`lucky_distinct`** work with one flat tuple of column names. `lucky_distinct` builds its own FROM clause, which is what `_get_table_clause` returned once there were no extras columns.
- **`sanitized_table`** selects `has_extras` from `meta_tables` only when psycodict still has that column, since the row is splatted positionally into `PostgresSearchTable`.
- **`seminar.py` / `talk.py`**: the `object_iterator` wrappers take `(cur, cols, projection)`, and the `objects=False` case returns `plain_iterator(table)` instead of the raw `_search_iterator`, so every iterator handed to `search_distinct` has one signature. `next_talks` was passing `db.talks._search_iterator` directly and now passes `plain_iterator(db.talks)`.
- The **`more`** pseudo-column, which `search_distinct` smuggled in by appending to `extra_cols`, is appended to the flat column tuple instead.

## Verification

Ran the new helpers — extracted verbatim from this branch's `utils.py` — against real psycodict checkouts from **both** before and after the removal, over a live table: projections by int / list / str / dict, iterator output, the `more` pseudo-column, and constructing a `PostgresSearchTable` from a `meta_tables` row. The probe flips as expected (`True` on the old psycodict, `False` on the new) and **every other result is identical**. pyflakes clean.

Worth noting: seminars has no test suite (CI is `pyflakes .`), so that manual cross-version check is the evidence here — a review of the `search_distinct` / `lucky_distinct` diffs against a real page load would be welcome before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)