### PR TITLE
Track psycodict's driver instead of importing psycopg2 directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ iso639
 PyYAML
 flask-login
 bcrypt
-psycopg2-binary
-git+https://github.com/roed314/psycodict.git
+# the pgbinary extra installs the driver psycodict itself is built on
+psycodict[pgbinary] @ git+https://github.com/roed314/psycodict.git
 pytz>=2021

--- a/seminars/create/main.py
+++ b/seminars/create/main.py
@@ -62,7 +62,7 @@ from seminars.lock import get_lock
 from seminars.users.pwdmanager import ilike_query, ilike_escape, userdb
 from seminars.utils import flash_error
 from psycodict.utils import IdentifierWrapper
-from psycopg2.sql import SQL
+from seminars.psycopg_compat import SQL
 from datetime import datetime, timedelta
 from math import ceil
 from dateutil.parser import parse as parse_time

--- a/seminars/importing/sanitize.py
+++ b/seminars/importing/sanitize.py
@@ -2,7 +2,7 @@
 
 import os, random, string, secrets, shutil
 from psycodict.utils import IdentifierWrapper, DelayCommit
-from psycopg2.sql import SQL, Identifier, Literal
+from seminars.psycopg_compat import SQL, Identifier, Literal, copy_table_to_file
 
 from seminars import db
 from seminars.seminar import seminars_search, _selecter as seminar_selecter
@@ -118,13 +118,11 @@ def write_content_table(data_folder, table, query, selecter, approve_row, users,
             now = time.time()
             if addid:
                 cols = ["id"] + cols
-            cols_wquotes = ['"' + col + '"' for col in cols]
-            cur = table._db.cursor()
             with open(filename, "w") as F:
                 try:
                     if write_header:
                         table._write_header_lines(F, cols, sep=sep)
-                    cur.copy_to(F, tbl, columns=cols_wquotes, sep=sep)
+                    copy_table_to_file(table._db, tbl, cols, F, sep)
                 except Exception:
                     table.conn.rollback()
                     raise

--- a/seminars/lock.py
+++ b/seminars/lock.py
@@ -1,4 +1,4 @@
-from psycopg2 import DatabaseError
+from seminars.psycopg_compat import DatabaseError
 from flask_login import current_user
 
 

--- a/seminars/psycopg_compat.py
+++ b/seminars/psycopg_compat.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+SQL composition classes and exceptions that track the driver psycodict is
+built on.
+
+psycodict is switching from psycopg2 to psycopg3 (roed314/psycodict#88).
+Query fragments composed here are executed by psycodict's ``_execute``, so
+they must come from the *same* driver psycodict uses -- and both drivers can
+be installed at once, so trying imports is not a valid probe.  Instead we key
+off psycodict's own re-exported ``SQL``.
+
+Once the psycodict requirement is pinned to a psycopg3-based release, the sql
+classes can be imported from psycodict itself (which re-exports them), the
+exceptions from ``psycopg``, and this module can be deleted.
+"""
+
+import psycodict
+
+_PSYCOPG2 = psycodict.SQL.__module__.startswith("psycopg2")
+
+if _PSYCOPG2:
+    from psycopg2 import DatabaseError
+    from psycopg2.sql import SQL, Composed, Identifier, Literal, Placeholder
+else:
+    from psycopg import DatabaseError
+    from psycopg.sql import SQL, Composed, Identifier, Literal, Placeholder
+
+__all__ = [
+    "SQL",
+    "Composed",
+    "Identifier",
+    "Literal",
+    "Placeholder",
+    "DatabaseError",
+    "copy_table_to_file",
+]
+
+
+def copy_table_to_file(db, tablename, columns, F, sep):
+    """
+    COPY the given columns of a table TO STDOUT with the given delimiter,
+    writing the rows to the open text file ``F``, under either driver.
+
+    (psycopg2 had ``cursor.copy_to``; psycopg3 replaced it with the
+    ``cursor.copy`` streaming interface.)
+    """
+    cur = db.cursor()
+    if _PSYCOPG2:
+        # copy_to quotes the column names itself since psycopg2 2.9; the
+        # manual quoting this helper replaced had been broken since then
+        cur.copy_to(F, tablename, columns=columns, sep=sep)
+    else:
+        copyto = SQL("COPY {0} ({1}) TO STDOUT (DELIMITER {2})").format(
+            Identifier(tablename),
+            SQL(", ").join(map(Identifier, columns)),
+            Literal(sep),
+        )
+        with cur.copy(copyto) as copy:
+            for data in copy:
+                F.write(bytes(data).decode())

--- a/seminars/seminar.py
+++ b/seminars/seminar.py
@@ -23,7 +23,7 @@ from .toggle import toggle
 from .utils import flash_error
 from psycodict.utils import DelayCommit, IdentifierWrapper
 from markupsafe import Markup
-from psycopg2.sql import SQL
+from seminars.psycopg_compat import SQL
 import pytz
 from collections import defaultdict
 from datetime import datetime

--- a/seminars/talk.py
+++ b/seminars/talk.py
@@ -26,7 +26,7 @@ from seminars.topic import topic_dag
 from seminars.seminar import WebSeminar, can_edit_seminar, audience_options
 from .utils import flash_error
 from markupsafe import Markup
-from psycopg2.sql import SQL
+from seminars.psycopg_compat import SQL
 import urllib.parse
 from icalendar import Event
 from datetime import datetime, timedelta

--- a/seminars/utils.py
+++ b/seminars/utils.py
@@ -11,11 +11,11 @@ from io import BytesIO
 from psycodict.utils import IdentifierWrapper
 from seminars.search_boxes import SearchBox
 from markupsafe import Markup, escape
-from psycopg2.sql import SQL
+from seminars.psycopg_compat import SQL
 from seminars import db
 from six import string_types
 from urllib.parse import urlparse, urlencode
-from psycopg2.sql import Placeholder
+from seminars.psycopg_compat import Placeholder
 import pytz
 import re
 from psycodict.searchtable import PostgresSearchTable


### PR DESCRIPTION
Companion to [roed314/psycodict#88](https://github.com/roed314/psycodict/pull/88) (the psycopg2→psycopg3 port), in the same spirit as #974: **deployable before or after psycodict's transition**.

## Changes

- New `seminars/psycopg_compat.py` provides `SQL`, `Composed`, `Identifier`, `Literal`, `Placeholder`, `DatabaseError` from whichever driver psycodict is built on (probed via `psycodict.SQL.__module__` — both drivers can be installed at once, so try/except imports would be wrong). All direct psycopg2 imports (`utils`, `seminar`, `talk`, `create/main`, `lock`, `importing/sanitize`) now go through it.
- `importing/sanitize.py`'s raw `cursor.copy_to` — an API psycopg3 removed outright — becomes `copy_table_to_file` in the compat module, branching per driver. **This also fixes a latent bug**: the manual column quoting the old code used has been broken since psycopg2 2.9 (which quotes columns itself), so the export raised `UndefinedColumn: column \"\"id\"\" does not exist` on any modern psycopg2 — it cannot have been run in years.
- `requirements.txt` installs `psycodict[pgbinary]` — the extra resolves to psycopg2-binary today and `psycopg[binary]` after the port — instead of naming psycopg2-binary directly.
- The `_psycodict_has_extras` probe from #974 is left in place; both it and this module's branch get deleted together once the psycodict requirement is pinned past the transition.

## Verification

Ran the compat module against **both** psycodict versions (current master on psycopg2, the port branch on psycopg 3.3.4) over a live server: all names resolve from the matching driver, composed statements execute through `_execute`, and `copy_table_to_file` produces **byte-identical** exports under both drivers, including delimiter escaping (values containing `|`). pyflakes clean.

As with #974: seminars has no test suite, so the cross-version run above is the evidence — a sanity load of the listing pages before deploying is still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)