### PR TITLE
Follow psycodict's API narrowing (psycodict#92)

### DIFF
--- a/seminars/__init__.py
+++ b/seminars/__init__.py
@@ -53,7 +53,9 @@ def insert_many(self, data, resort=False, reindex=False, restat=False):
 
 
 for tname in db.tablenames:
-    db[tname].log_db_change = nothing
+    # both names, so the no-op takes effect whichever one the installed
+    # psycodict calls (it became _log_db_change in roed314/psycodict#92)
+    db[tname].log_db_change = db[tname]._log_db_change = nothing
     # db[tname].add_column = are_you_REALLY_sure(db[tname].add_column)
     db[tname].drop_column = are_you_REALLY_sure(db[tname].drop_column)
     db[tname].update = update.__get__(db[tname])

--- a/seminars/psycopg_compat.py
+++ b/seminars/psycopg_compat.py
@@ -44,7 +44,7 @@ def copy_table_to_file(db, tablename, columns, F, sep):
     (psycopg2 had ``cursor.copy_to``; psycopg3 replaced it with the
     ``cursor.copy`` streaming interface.)
     """
-    cur = db.cursor()
+    cur = (getattr(db, "_cursor", None) or db.cursor)()
     if _PSYCOPG2:
         # copy_to quotes the column names itself since psycopg2 2.9; the
         # manual quoting this helper replaced had been broken since then

--- a/seminars/users/pwdmanager.py
+++ b/seminars/users/pwdmanager.py
@@ -47,7 +47,7 @@ class PostgresUserTable(PostgresSearchTable):
             self, db=db, search_table="users", label_col="email", include_nones=True
         )
         # FIXME
-        self._rw_userdb = db.can_read_write_userdb()
+        self._rw_userdb = (getattr(db, "_can_read_write_userdb", None) or db.can_read_write_userdb)()
 
     def log_db_change(self, what, **kwargs):
         " no need to log the changes "


### PR DESCRIPTION
Companion to [roed314/psycodict#92](https://github.com/roed314/psycodict/pull/92) (underscore-prefixing psycodict methods that are not public API). **Stacked on #977** — the base commits here are that PR's; merge it first and this reduces to one commit.

Three call sites use names that PR renames, each made version-tolerant so this can merge before or after psycodict#92:

- `seminars/__init__.py`: the per-table `log_db_change` no-op is now bound under **both** the old and new names, so the hook is disabled whichever one the installed psycodict calls (this is the important one — a missed rename here would silently re-enable logging calls into nonexistent tables).
- `seminars/psycopg_compat.py`: the copy helper reaches the cursor via `_cursor` when it exists, falling back to `cursor`.
- `seminars/users/pwdmanager.py`: same pattern for `can_read_write_userdb`.

Verified by running the copy-helper compat check against both psycodict versions (pre- and post-rename): byte-identical COPY output, and the tolerant branches each got exercised. Simplify all three once seminars pins psycodict past the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
