### PR TITLE
Fix /health for psycodict's is_alive -> _is_alive rename

### DIFF
--- a/seminars/app.py
+++ b/seminars/app.py
@@ -273,7 +273,10 @@ def alive():
     """
     from . import db
 
-    if db.is_alive():
+    # is_alive became _is_alive in roed314/psycodict#92; accept either name so
+    # this works whichever psycodict is installed (matches the fallbacks in
+    # psycopg_compat.py and users/pwdmanager.py).
+    if (getattr(db, "_is_alive", None) or db.is_alive)():
         return "Bean Theory!"
     else:
         abort(503)


### PR DESCRIPTION
The `/health` (and `/alive`) route calls `db.is_alive()`, which psycodict#92 underscore-prefixed to `_is_alive`. #978 added the version-tolerant getattr fallback at the other renamed call sites (`psycopg_compat.py`, `users/pwdmanager.py`) but missed this one, so `/health` 500s with `AttributeError: 'PostgresDatabase' object has no attribute 'is_alive'` against a post-#92 psycodict.

This was the single red job on [psycodict#92](https://github.com/roed314/psycodict/pull/92) once its downstream companions (this repo's #978 and LMFDB/lmfdb#7072) merged — lmfdb#7072 patched all three of its `is_alive` call sites the same way; seminars just had this straggler.

Fix: the same `(getattr(db, "_is_alive", None) or db.is_alive)()` fallback, so `/health` works whether the installed psycodict exposes `is_alive` (pre-#92) or `_is_alive` (post-#92). Verified: `pyflakes .` clean, and the fallback resolves correctly under both method names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)