### PR TITLE
Fix login crash under psycodict 1.0

### DIFF
--- a/seminars/users/pwdmanager.py
+++ b/seminars/users/pwdmanager.py
@@ -200,7 +200,9 @@ class SeminarsUser(UserMixin):
     The User Object
     """
 
-    properties = sorted(userdb.col_type) + ["id"]
+    # col_type already includes "id", so no need to append it separately
+    # (psycodict >= 1.0 rejects a duplicated column in a list projection)
+    properties = sorted(userdb.col_type)
 
     def __init__(self, uid=None, email=None):
         if email:


### PR DESCRIPTION
The fix is to drop duplicate "id" in user projection.  userdb.col_type already contains "id" (only search_cols excludes it), so sorted(userdb.col_type) + ["id"] listed the column twice.  Pre-1.0 psycodict silently tolerated this (both entries just set include_id), but 1.0.0rc1 rejects a repeated column in a list projection, so every request that loaded a user died with ValueError: Duplicate column(s) in projection: id.